### PR TITLE
docs: reorganize and improve documentation

### DIFF
--- a/docs/source/connecting/authentication.md
+++ b/docs/source/connecting/authentication.md
@@ -1,0 +1,96 @@
+# Authentication
+
+The Node.js RS Driver supports both username/password authentication and SSL/TLS connections.
+
+> **Important:** Authentication credentials are sent in plain text to the server. For this reason,
+> it is strongly recommended to use authentication together with SSL/TLS encryption, or only in
+> a trusted network environment.
+
+## Username and Password Authentication
+
+To connect with username/password credentials, provide them in the `credentials` option:
+
+```javascript
+const { Client } = require('scylladb-driver-alpha');
+
+(async () => {
+  const client = new Client({
+    contactPoints: ['127.0.0.1'],
+    localDataCenter: 'datacenter1',
+    credentials: {
+      username: 'cassandra',
+      password: 'cassandra',
+    },
+  });
+
+  await client.connect();
+})();
+```
+
+The `credentials` object accepts:
+
+- `username` - the username to authenticate with
+- `password` - the password to authenticate with
+
+These map directly to ScyllaDB's built-in `PasswordAuthenticator`. Ensure that the authenticator
+is enabled in your ScyllaDB configuration (`authenticator: PasswordAuthenticator` in `scylla.yaml`).
+
+## SSL/TLS
+
+To connect over SSL, provide an `sslOptions` object. The SSL options are passed directly to Node.js's
+[`tls.connect()`](https://nodejs.org/api/tls.html#tlsconnectoptions-callback):
+
+```javascript
+const fs = require('fs');
+const { Client } = require('scylladb-driver-alpha');
+
+(async () => {
+  const client = new Client({
+    contactPoints: ['127.0.0.1'],
+    localDataCenter: 'datacenter1',
+    sslOptions: {
+      ca: fs.readFileSync('/path/to/ca.crt'),
+      cert: fs.readFileSync('/path/to/client.crt'),
+      key: fs.readFileSync('/path/to/client.key'),
+      rejectUnauthorized: true,
+    },
+  });
+
+  await client.connect();
+})();
+```
+
+Common SSL options:
+
+| Option               | Description                                                   |
+|----------------------|---------------------------------------------------------------|
+| `ca`                 | CA certificate (Buffer or string) to verify the server cert  |
+| `cert`               | Client certificate for mutual TLS authentication             |
+| `key`                | Client private key for mutual TLS authentication             |
+| `rejectUnauthorized` | Whether to reject connections with invalid certificates       |
+
+## Using Both Authentication and SSL
+
+You can combine username/password authentication with SSL for secure connections:
+
+```javascript
+const fs = require('fs');
+const { Client } = require('scylladb-driver-alpha');
+
+(async () => {
+  const client = new Client({
+    contactPoints: ['127.0.0.1'],
+    localDataCenter: 'datacenter1',
+    credentials: {
+      username: 'cassandra',
+      password: 'cassandra',
+    },
+    sslOptions: {
+      ca: fs.readFileSync('/path/to/ca.crt'),
+      rejectUnauthorized: true,
+    },
+  });
+
+  await client.connect();
+})();
+```

--- a/docs/source/getting-started/getting-started.md
+++ b/docs/source/getting-started/getting-started.md
@@ -1,0 +1,115 @@
+# Getting Started
+
+This page will guide you through installing the Node.js RS Driver and executing your first statements against ScyllaDB.
+
+## Installation
+
+Install the driver using npm:
+
+```bash
+npm install scylladb-driver-alpha
+```
+
+**Supported architectures:** Linux x86_64 and Linux ARM.
+
+## Connecting to ScyllaDB
+
+Create a `Client` instance and connect to your ScyllaDB cluster:
+
+```javascript
+const { Client } = require('scylladb-driver-alpha');
+
+(async () => {
+  const client = new Client({
+    contactPoints: ['127.0.0.1'],
+    localDataCenter: 'datacenter1',
+  });
+
+  await client.connect();
+  console.log('Connected to ScyllaDB');
+})();
+```
+
+For connecting with authentication, see the [Authentication](../connecting/authentication.md) page.
+
+## Executing a Statement
+
+Once connected, you can execute CQL statements. It is strongly recommended to use **prepared statements** for repeated operations, as they improve performance and enable advanced load balancing:
+
+```javascript
+// Prepared statement (recommended for repeated execution)
+const result = await client.execute(
+  'SELECT keyspace_name FROM system_schema.keyspaces',
+  [],
+  { prepare: true }
+);
+
+for (const row of result.rows) {
+  console.log(row['keyspace_name']);
+}
+```
+
+For a detailed overview of statement types and best practices, see [Executing CQL statements](../statements/index.md).
+
+## Full Example: Create Table and Insert Data
+
+The following example creates a keyspace and table, inserts a row, and reads it back:
+
+```javascript
+const { Client, types } = require('scylladb-driver-alpha');
+
+async function main() {
+  const client = new Client({
+    contactPoints: ['127.0.0.1'],
+    localDataCenter: 'datacenter1',
+  });
+
+  await client.connect();
+
+  // Create a keyspace
+  await client.execute(
+    `CREATE KEYSPACE IF NOT EXISTS examples
+     WITH replication = {'class': 'NetworkTopologyStrategy', 'datacenter1': 1}`
+  );
+
+  // Create a table
+  await client.execute(
+    `CREATE TABLE IF NOT EXISTS examples.basic (
+       id uuid PRIMARY KEY,
+       name text,
+       value int
+     )`
+  );
+
+  // Insert a row using a prepared statement
+  const id = types.Uuid.random();
+  await client.execute(
+    'INSERT INTO examples.basic (id, name, value) VALUES (?, ?, ?)',
+    [id, 'Hello, ScyllaDB!', 42],
+    { prepare: true }
+  );
+
+  // Read the row back
+  const result = await client.execute(
+    'SELECT id, name, value FROM examples.basic WHERE id = ?',
+    [id],
+    { prepare: true }
+  );
+
+  const row = result.first();
+  console.log(`id: ${row['id']}, name: ${row['name']}, value: ${row['value']}`);
+
+  await client.shutdown();
+}
+
+main().catch(console.error);
+```
+
+## Next Steps
+
+- [Executing CQL statements - best practices](../statements/index.md) - Learn about prepared, unprepared, and batch statements
+- [Fetching large result sets](../paging/paging.md) - Page through large query results efficiently
+- [Load balancing](../policies/load-balancing.md) - Configure how the driver routes requests
+- [Authentication](../connecting/authentication.md) - Connect with credentials or SSL
+- [Migration guide](../migration-guide/migration-guide.md) - Migrating from the Apache `cassandra-driver`
+- [Examples](https://github.com/scylladb/nodejs-rs-driver/tree/main/examples) - More complete usage examples

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,10 +1,10 @@
 ==============================
-ScyllaDB Node.js-RS Driver
+ScyllaDB Node.js RS Driver
 ==============================
 
 A client-side driver for `ScyllaDB <https://www.scylladb.com/>`_ written in Node.js and Rust.
 This driver is an overlay over the `ScyllaDB Rust Driver <https://github.com/scylladb/scylla-rust-driver>`_,
-with the interface based on the `DataStax Node.js Driver <https://github.com/datastax/nodejs-driver>`_.
+with the interface based on the `Apache cassandra-driver <https://github.com/apache/cassandra-nodejs-driver>`_.
 Although optimized for ScyllaDB, the driver is also compatible with `Apache Cassandra® <https://cassandra.apache.org/>`_.
 
 .. caution::
@@ -16,29 +16,31 @@ Although optimized for ScyllaDB, the driver is also compatible with `Apache Cass
    :maxdepth: 2
    :hidden:
 
-   api/index
+   getting-started/getting-started
    statements/index
    paging/paging
    policies/index
+   connecting/authentication
    shutdown/shutdown
    migration-guide/migration-guide
+   api/index
 
-Getting Started
-===============
+Contents
+========
 
-Installation
-------------
+- :doc:`Getting Started <getting-started/getting-started>` - Installing the driver and executing your first statements
+- :doc:`Statements <statements/index>` - Prepared, unprepared, and batch statements
 
-.. code-block:: bash
+  - :doc:`Executing CQL Statements - Best Practices <statements/prepared>`
+  - :doc:`Unprepared Statements <statements/unprepared>`
+  - :doc:`Batch Statements <statements/batch>`
 
-   npm install scylladb-driver-alpha
-
-Currently only Linux x86_64 architecture is supported, with planned support for other architectures in the future.
-
-Examples
---------
-
-You can find example usages of the driver in the `examples directory <https://github.com/scylladb/nodejs-rs-driver/tree/main/examples>`_.
+- :doc:`Fetching Large Result Sets <paging/paging>` - Paging through large result sets
+- :doc:`Policies <policies/index>` - Load balancing and retry policies
+- :doc:`Authentication <connecting/authentication>` - Connecting with credentials or SSL
+- :doc:`Shutdown <shutdown/shutdown>` - How the driver manages connection lifecycle
+- :doc:`Migration Guide <migration-guide/migration-guide>` - Migrating from the Apache ``cassandra-driver``
+- :doc:`API Reference <api/index>` - Full API documentation
 
 Features
 ========
@@ -64,13 +66,12 @@ Roadmap
 Features planned for the driver to become production ready:
 
 - Configurable load balancing and retry policies
-- Faster performance, compared to DataStax Node.js driver
-- Migration guide from the DataStax driver
+- Faster performance, compared to Apache cassandra-driver
 
 For other planned features, see the `Milestones <https://github.com/scylladb/nodejs-rs-driver/milestones>`_.
 
-Reference
-=========
+Other resources
+===============
 
-* :doc:`API Reference <api/index>`
 * `CQL binary protocol specification version 4 <https://github.com/apache/cassandra/blob/trunk/doc/native_protocol_v4.spec>`_
+* `Examples <https://github.com/scylladb/nodejs-rs-driver/tree/main/examples>`_

--- a/docs/source/migration-guide/migration-guide.md
+++ b/docs/source/migration-guide/migration-guide.md
@@ -1,4 +1,22 @@
-# Migration guide
+# Migration Guide
+
+This guide describes the differences between the ScyllaDB Node.js RS Driver
+and the Apache `cassandra-driver` (formerly the DataStax `cassandra-driver`, which was transferred to Apache),
+to help you migrate existing applications.
+
+## Shutdown behavior
+
+In the Apache `cassandra-driver`, you can explicitly close the connection to the database using `client.shutdown()`.
+The ScyllaDB Node.js RS Driver behaves differently: it is not possible to explicitly close the connection.
+The connection is closed when the `Client` object is garbage collected.
+
+When `client.shutdown()` is called in the Node.js RS Driver:
+- It prevents execution of any new statements with the given client.
+- It does **not** close the connection to the database.
+- It does **not** deallocate connection-related structures.
+- It does **not** stop queries that are currently in flight.
+
+See [Shutdown](../shutdown/shutdown.md) for more details.
 
 ## Query options
 
@@ -34,17 +52,26 @@ The following options remain unchanged:
 - `maxPrepared`
 
 The following option implementation has changed significantly,
-but the meaning of those option remains unchanged:
+but the meaning of the option remains unchanged:
 
-- `id`: Now accepts both uuid and string types. When uuid is provided, it will be passed to the database in standard string representation.
+- `id`: Now accepts both `Uuid` and string types. When a `Uuid` is provided, it will be passed to the database in its standard string representation.
 
-The following options' default values have changes:
+The following options' default values have changed:
 
 - `encoding.useBigIntAsLong`: New default - `true` (previously - `false`),
 - `encoding.useBigIntAsVarint`: New default - `true` (previously - `false`)
 
 With the update of encoding options, we encourage usage of the builtin types.
 The ability to use the driver with types is kept as a legacy option, and may be removed in the future.
+
+## Unprepared statements with bind markers
+
+When an unprepared statement contains bind markers (`?`), the driver silently
+prepares the statement before execution. This is especially important in batches: for each
+statement with a non-empty list of values, the driver sends a prepare request **sequentially**,
+and results are **not cached** between `client.batch()` calls.
+
+Avoid using unprepared batches unless all statements take no bind markers.
 
 ## Load balancing policies
 

--- a/docs/source/paging/paging.md
+++ b/docs/source/paging/paging.md
@@ -3,31 +3,30 @@ https://docs.datastax.com/en/developer/nodejs-driver/4.8/features/paging/index.h
 and rust driver documentation:
 https://rust-driver.docs.scylladb.com/stable/statements/paged.html -->
 
-# Fetching large result sets
+# Fetching Large Result Sets
 
 When dealing with a large number of rows, the driver breaks the result into _pages_, only requesting a limited number of
 rows each time (`5000` being the default `fetchSize`). To retrieve the rows beyond this default size, use one of the
 following paging mechanisms. Paging is enabled by default and you can disable paging by setting `QueryOptions.paged` to false.
 
-:::{warning}
-Issuing unpaged SELECTs
-may have dramatic performance consequences! **BEWARE!**\
-If the result set is big (or, e.g., there are a lot of tombstones), those atrocities can happen:
+:::{caution}
+Issuing unpaged SELECTs can have significant performance consequences.
+If the result set is large (or there are many tombstones), the following problems may occur:
 
-- cluster may experience high load,
+- the cluster may experience high load,
 - queries may time out,
-- the driver may devour a lot of RAM,
-- latency will likely spike.
+- the driver may consume large amounts of RAM,
+- latency will likely increase.
 
-Stay safe. Page your SELECTs.
+Always page your SELECTs.
 :::
 
 ## Automatic paging
 
 ### Async iterators
 
-The driver supports asynchronous iteration of the `ResultSet` using the built-in [Async Iterator][async-it], fetching
-the following result pages after the previous one has been yielded.
+The driver supports asynchronous iteration of the `ResultSet` using the built-in [Async Iterator][async-it],
+fetching subsequent pages automatically as the previous one has been consumed.
 
 Large result sets can be iterated using the [`for await ... of`][for-of-await] statement:
 
@@ -41,18 +40,18 @@ for await (const row of result) {
 
 Under the hood, the driver will get all the rows of the query result using multiple requests. Initially,
 when calling `execute()` it will retrieve the first page of results according to the fetch size (defaults to `5000`).
-If there are additional rows, those will be retrieved once the async iterator yielded the rows from the previous page.
+If there are additional rows, the driver fetches the next page automatically once the async iterator
+has yielded rows from the previous page.
 
 If needed, you can use `isPaged()` method of `ResultSet` instance to determine whether there are more pages of results
 than initially fetched.
 
-:::{warning}
-Note that using either the async or sync iterators will not affect the internal state of the `ResultSet` instance.
-The following methods are mutually exclusive, so you should use only one per ResultSet instance:
+:::{note}
+The following iteration methods are mutually exclusive — use only one per `ResultSet` instance:
 
-- rows property, which contains the row instances of the first page of results,
-- sync iterator, which will yield all the rows in the current page,
-- async iterator, which will yield all the rows in the result regardless of the number of pages.
+- `rows` property: contains the row instances of the first page of results,
+- sync iterator: yields all rows in the current page,
+- async iterator: yields all rows in the result regardless of the number of pages.
 :::
 
 ### Each row callback
@@ -60,8 +59,8 @@ The following methods are mutually exclusive, so you should use only one per Res
 You can also iterate through pages by setting a per-page callback.
 `eachRow()` works in two modes, depending on the `QueryOptions.autoPage` configuration:
 
-- automatic paging: keeps fetching pages until all rows are processed (this is the default mode),
-- manual paging: fetches one page at a time. This mode gives you access to result sets of intermediate pages.
+- **Automatic paging** (default): keeps fetching subsequent pages until all rows are processed.
+- **Manual paging**: fetches one page at a time. This mode gives you access to result sets of intermediate pages.
   To fetch the next page, you need to call `result.nextPage()`.
 
 `eachRow()` calls:
@@ -159,15 +158,15 @@ safe to expose it to the users in plain text.
 
 ## Best practices
 
-| Query result fetching   | Unpaged                                                                                                                 | Paged manually                                                                                       | Paged automatically                                                                               |
-|-------------------------|-------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------|
-| Exposed Client API      | `execute` with `QueryOptions.paged = false`                                                                             | `execute` with `QueryOptions.pageState`                                                              | Async iterators, each row callbacks, streams                                                      |
-| Working                 | get all results in a single CQL frame, into a single result set                                                         | get one page of results in a single CQL frame, into a single result set                              | upon high-level iteration, fetch consecutive CQL frames and transparently iterate over their rows |
-| Cluster load            | potentially **HIGH** for large results, beware!                                                                         | normal                                                                                               | normal                                                                                            |
-| Driver overhead         | low - simple frame fetch                                                                                                | low - simple frame fetch                                                                             | low - simple frame fetch                                                                          |
-| Driver memory footprint | potentially **BIG** - all results have to be stored at once!                                                            | small - only one page stored at a time                                                               | small - at most constant number of pages stored at a time                                         |
-| Latency                 | potentially **BIG** - all results have to be generated at once!                                                         | considerable on page boundary - new page needs to be fetched                                         | considerable on page boundary - new page needs to be fetched                                      |
-| Suitable operations     | - in general: operations with empty result set (non-SELECTs)</br> - as possible optimisation: SELECTs with LIMIT clause | - for advanced users who prefer more control over paging                                             | - in general: all SELECTs                                                                         |
+| Query result fetching     | Unpaged                                                                                                                 | Paged manually                                                                                       | Paged automatically                                                                               |
+|---------------------------|-------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------|
+| Exposed Client API        | `execute` with `QueryOptions.paged = false`                                                                             | `execute` with `QueryOptions.pageState`                                                              | Async iterators, each row callbacks, streams                                                      |
+| Working                   | get all results in a single CQL frame, into a single result set                                                         | get one page of results in a single CQL frame, into a single result set                              | upon high-level iteration, fetch consecutive CQL frames and transparently iterate over their rows |
+| Cluster load              | potentially **HIGH** for large results, beware!                                                                         | normal                                                                                               | normal                                                                                            |
+| Driver overhead           | low - simple frame fetch                                                                                                | low - simple frame fetch                                                                             | low - simple frame fetch                                                                          |
+| Driver memory footprint   | potentially **BIG** - all results have to be stored at once!                                                            | small - only one page stored at a time                                                               | small - at most constant number of pages stored at a time                                         |
+| Latency                   | potentially **BIG** - all results have to be generated at once!                                                         | considerable on page boundary - new page needs to be fetched                                         | considerable on page boundary - new page needs to be fetched                                      |
+| Suitable operations       | - in general: operations with empty result set (non-SELECTs)</br> - as possible optimisation: SELECTs with LIMIT clause | - for advanced users who prefer more control over paging                                             | - in general: all SELECTs                                                                         |
 
 [stream]: https://nodejs.org/api/stream.html
 [async-it]: https://github.com/tc39/proposal-async-iteration

--- a/docs/source/policies/load-balancing.md
+++ b/docs/source/policies/load-balancing.md
@@ -1,4 +1,4 @@
-# Load balancing
+# Load Balancing
 
 We recommend to configure load balancing options using only `DefaultLoadBalancingPolicy`.
 While some of the other built-in policies that were present in the DataStax driver,
@@ -9,8 +9,8 @@ existing policies, see [migration guide](../migration-guide/migration-guide.md#l
 
 ## Configuring a DefaultLoadBalancingPolicy
 
-`DefaultLoadBalancingPolicy` can be configured only at its creation.
-The following fields can be configured:
+`DefaultLoadBalancingPolicy` is configured only at creation time.
+You can set all or a subset of these options:
 
 - `preferDatacenter` (default: `null` - no preference)
 - `preferRack` (default: `null` - no preference)
@@ -20,8 +20,6 @@ The following fields can be configured:
 - `allowList` (default: `null` - all hosts are accepted)
 
 You can assume `undefined` is equivalent to `null` for the purpose of all configurations.
-
-You can set all, or only some of those options:
 
 ```js
 const DefaultLoadBalancingPolicy = require("scylladb-driver-alpha").policies.loadBalancing.DefaultLoadBalancingPolicy;
@@ -59,12 +57,13 @@ in the preferred datacenter, and then the other replicas in the datacenter
 (followed by remote replicas). After replicas, the other nodes will be ordered
 similarly, too (local rack nodes, local datacenter nodes, remote nodes).
 
-When datacenter failover is disabled (`permitDcFailover` is set to
-false), the default policy will only include local nodes in load balancing
-plans. Remote nodes will be excluded, even if they are alive and available to
-serve requests.
+When `permitDcFailover` is `false` (the default), only local nodes are included
+in load balancing plans. Remote nodes are excluded even if they are available.
 
-### Datacenter Failover
+When `permitDcFailover` is `true`, the policy will prefer alive remote replicas
+if local nodes are unavailable and consistency constraints permit.
+
+#### Datacenter Failover
 
 In the event of a datacenter outage or network failure, the nodes in that
 datacenter may become unavailable, and clients may no longer be able to access
@@ -77,7 +76,7 @@ Datacenter failover can be enabled in `DefaultLoadBalancingPolicy` by
 prefer to return alive remote replicas if datacenter failover is permitted and
 possible due to consistency constraints.
 
-### Token awareness
+### Token Awareness
 
 Token awareness refers to a mechanism by which the driver is aware of the token
 range assigned to each node in the cluster. Tokens are assigned to nodes to
@@ -97,12 +96,12 @@ to that node first, assuming it is alive and responsive.
 Token awareness can significantly improve the performance and scalability of
 applications built on Scylla. By using token awareness, users can ensure that
 data is accessed locally as much as possible, reducing network overhead and
-improving throughput.
+improving throughput and latency.
 
 Please note that for token awareness to be applied, a statement must be
 prepared before being executed.
 
-### Replica shuffling
+### Replica Shuffling
 
 Setting `enableShufflingReplicas` to `false` (default: `true`) does something
 slightly different than its name suggests. It will cause all randomness-based
@@ -119,7 +118,6 @@ return replicas in the same order. We discourage its use in production setting.
 You may want to limit the driver ability to connect to certain nodes.
 It can be achieved by providing an allow list - list of hosts in
 `ip:port` format, that can be used, when connecting to the database.
-When this option is provided, any of the hosts that is not on the allow
-list will be ignored when connecting to the database.
+When this option is provided, any host not on the list is ignored, i.e., the driver does not open any connections to it.
 When this option is empty (set to `null`), all hosts (unless filtered by other load balancing options)
 can be used when connecting to the database.

--- a/docs/source/policies/retry-policy.md
+++ b/docs/source/policies/retry-policy.md
@@ -1,4 +1,4 @@
-# Retry policies
+# Retry Policies
 
 Currently the driver supports only built-in policies. This includes the following policies:
 

--- a/docs/source/shutdown/shutdown.md
+++ b/docs/source/shutdown/shutdown.md
@@ -1,17 +1,20 @@
 # Shutdown
 
-It is not possible to explicitly close connection to the database.
-A connection is closed when the client variable associated with this connection is collected by the garbage collector.  
+It is not possible to explicitly close the connection to the database.
+The connection is closed when the `Client` object is garbage collected.
 Even though removal of references to the object is explicit,
 the actual GC run that frees objects that have no active references to is implicit.
 
-In the DataStax NodeJS driver, it is possible to explicitly close the connection to the database.
-In contrast, the ScyllaDB Rust driver, which this driver relies upon,
+In the Apache `cassandra-driver`, it is possible to explicitly close the connection to the database.
+In contrast, the ScyllaDB Rust Driver, which this driver relies upon,
 shuts down the connection when the value representing given session is dropped.
 
 ## client.shutdown()
 
-To maintain compatibility with the DataStax driver API, it's possible to call ``shutdown`` on a given client.
-This endpoint is marked as deprecated and may be removed in the future. Currently the only functionality
-it provides is preventing execution of any new queries with the given client. It does **not** close connection
-to the database nor deallocate any structures related to that connection nor stop any queries being currently executed.
+To maintain compatibility with the `cassandra-driver` API, it's possible to call `shutdown` on a given client.
+This method is marked as deprecated and may be removed in the future. Currently the only functionality
+it provides is preventing execution of any new statements with the given client. It does **not**:
+
+- Close the connection to the database.
+- Deallocate connection-related structures.
+- Stop queries that are currently in flight.

--- a/docs/source/statements/batch.md
+++ b/docs/source/statements/batch.md
@@ -3,19 +3,20 @@ https://docs.datastax.com/en/developer/nodejs-driver/4.8/features/batch/index.ht
 and rust driver documentation:
 https://rust-driver.docs.scylladb.com/stable/statements/batch.html -->
 
-# Batch statements
+# Batch Statements
 
 It's common for applications to require atomic batching of multiple `INSERT`, `UPDATE`, or `DELETE` statements, even in
 different partitions or column families. The driver allows you to execute multiple statements atomically
 without the need to concatenate multiple queries.
 
-> ***Warning***\
+:::{note}
 Batches containing statements that target different partitions will no longer
 be correctly token- and shard-aware, which will hurt performance.
 Batches should not normally be used to boost performance in ScyllaDB.
 Batches' goal is enabling atomicity, not increased efficiency.
 If you want to execute multiple statements efficiently and you do not
 care about atomicity of the operation, we would recommend using `executeConcurrent` endpoint.
+:::
 
 The method `batch()` accepts the list of queries as first parameter.
 Each query can be either just a statement string, or `{ query, params }` object:
@@ -48,16 +49,18 @@ client.batch(queries, { prepare: true }, function (err) {
 });
 ```
 
-By preparing your queries, you will get the best performance and your JavaScript parameters correctly mapped to
-Cassandra types. The driver will prepare each query once on each host and execute the batch every time with the
+By preparing your statements, you will get the best performance and your JavaScript parameters correctly mapped to
+Cassandra types. The driver will prepare each statement once on each host and execute the batch every time with the
 different parameters provided.
 
-> ***Warning***\
-> Using unprepared statements with bind markers in batches is strongly discouraged.
-> For each unprepared statement with a non-empty list of values in the batch,
-> the driver will send a prepare request, and it will be done **sequentially**.
-> Results of preparation are not cached between `batch` calls.
-> Consider preparing the statements before putting them into the batch.
+:::{note}
+When an unprepared statement contains bind markers (`?`), the driver silently
+prepares the statement before execution. This is especially important in batches: for each
+statement with a non-empty list of values, the driver sends a prepare request **sequentially**,
+and results are **not cached** between `client.batch()` calls.
+
+Avoid using unprepared batches unless all statements take no bind markers.
+:::
 
 Note that batches are not suitable for bulk loading, there are dedicated tools for that. Batches allow you
 to group related updates in a single request, so keep the batch size small (in the order of tens).

--- a/docs/source/statements/prepared.md
+++ b/docs/source/statements/prepared.md
@@ -3,9 +3,9 @@ https://rust-driver.docs.scylladb.com/stable/statements/statements.html
 and DSx driver documentation:
 https://docs.datastax.com/en/developer/nodejs-driver/4.8/coding-rules/index.html -->
 
-# Executing CQL statements - best practices
+# Executing CQL Statements - Best Practices
 
-Driver supports all kinds of statements supported by ScyllaDB. The following tables aim to bridge between DB concepts and driver's API.
+The Node.js RS Driver supports all kinds of statements supported by ScyllaDB. The following tables aim to bridge between DB concepts and driver's API.
 They include recommendations on which API to use in what cases.
 
 ## Kinds of CQL statements (from the CQL protocol point of view)
@@ -17,26 +17,25 @@ They include recommendations on which API to use in what cases.
 
 This is **NOT** strictly related to content of the CQL statement string.
 
-> ***Interesting note***\
-> In fact, any kind of CQL statement could contain any CQL statement string.
-> Yet, some of such combinations don't make sense and will be rejected by the DB.
-> For example, SELECTs in a Batch are nonsense.
+> **Note:** Any kind of CQL statement could technically contain any CQL statement string.
+> However, not all combinations are valid — some will be rejected by the database.
+> For example, SELECT statements are not permitted inside a batch.
 
 ### [Unprepared](./unprepared.md) vs Prepared
 
-> ***GOOD TO KNOW***\
-> Each time a statement is executed by sending a statement string to the DB, it needs to be parsed. Driver does not parse CQL, therefore it sees statement strings as opaque.\
-> There is an option to *prepare* a statement, i.e. parse it once by the DB and associate it with an ID. After preparation, it's enough that the driver sends the ID
-> and the DB already knows what operation to perform - no more expensive parsing necessary! Moreover, upon preparation driver receives valuable data for load balancing,
-> enabling advanced load balancing (so better performance!) of all further executions of that prepared statement.\
-> ***Key takeaway:*** always use prepared statements that you are going to execute multiple times.
+Each time a statement is executed by sending a statement string to the DB, it needs to be parsed. The driver does not parse CQL, therefore it sees statement strings as opaque.
+There is an option to *prepare* a statement, i.e. parse it once by the DB and associate it with an ID. After preparation, it's enough that the driver sends the ID
+and the DB already knows what operation to perform — no more expensive parsing necessary. Moreover, upon preparation the driver receives valuable data for load balancing,
+enabling advanced load balancing (and better performance) of all further executions of that prepared statement.
+
+**Key takeaway:** always use prepared statements that you are going to execute multiple times.
 
 You can decide whether a given query will be prepared by setting the `QueryOptions.prepare` option. By default, queries are unprepared.
-You do not need to manually handle statement preparation. If you enable the `prepare` option, the driver handles the rest: it either uses its cache of prepared statements
-if the statement is present, or prepares the query before execution.
+You do not need to manually handle statement preparation. If you enable the `prepare` option, the driver handles the rest: it either uses
+its cache of prepared statements if the statement is present, or prepares the query before execution and keeps the prepared statement in its cache from now on.
 The driver keeps a cache of the last `ClientOptions.maxPrepared` statements. This cache ensures you can take full advantage of prepared statements.
 
-:::{warning}
+:::{caution}
 **Ensure sufficient cache size.** If you execute more than `ClientOptions.maxPrepared` different statements, you will experience cache flickering, defeating the purpose of prepared
 statements and significantly decreasing driver performance.
 :::
@@ -63,14 +62,14 @@ In case of unprepared statements, this metadata is missing and thus verification
 While it's possible to [manually provide metadata](./unprepared.md), this allows some silent bugs to sneak into user applications in case the provided metadata is invalid.
 
 <!-- Well. While the rust driver still silently prepares with the goal of ensuring type safety. We just totally ignore the verification part. -->
-:::{warning}
-When the unprepared statement contains bind markers, the driver silently prepares the statement before execution.
-That behaviour is especially important in batches:
-For each simple statement with a non-empty list of values in the batch,
-the driver will send a prepare request, and it will be done **sequentially**!
-Results of preparation are not cached between `client.batch` calls.
+:::{note}
+When an unprepared statement contains bind markers (`?`), the driver silently
+prepares the statement before execution. This is especially important in batches:
+for each statement with a non-empty list of values in the batch,
+the driver will send a prepare request, and it will be done **sequentially**.
+Results of preparation are not cached between `client.batch()` calls.
 
-Takeaway from the above: Do NOT use unprepared batches, unless all statements take no bind markers.
+Avoid using unprepared batches unless all statements take no bind markers.
 :::
 
 ### Single vs [Batch](./batch.md)
@@ -91,11 +90,8 @@ means that your batch is no longer atomic.
 
 ### [Paged](../paging/paging.md) vs Unpaged queries
 
-> ***GOOD TO KNOW***\
-> SELECT statements return a result set, possibly a large one. Therefore, paging is available to fetch it in chunks, relieving load on the cluster and lowering latency.\
-> ***Key takeaways:***\
-> For SELECTs you had better **avoid unpaged queries**.\
-> For non-SELECTs, it's preferred to have unpaged queries.
+SELECT statements return a result set, possibly a large one. Paging is available to fetch it in chunks, relieving load on the cluster and lowering latency.
+For SELECTs, avoid unpaged queries. For non-SELECTs, unpaged queries are preferred.
 
 | Query result fetching | Unpaged                                                                                                                 | Paged                                                                                                                                                          |
 |-----------------------|-------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -116,4 +112,4 @@ For more detailed comparison and more best practices, see doc page about [paging
 | INSERT, UPDATE                                 | Prepared statement if repeated, unprepared statement if once, batch if multiple statements are to be executed atomically                                             | No. While you can still use paging, it is irrelevant, because the result set of such operation is empty                                  |
 | CREATE/DROP {KEYSPACE, TABLE, TYPE, INDEX,...} | Unprepared statement, batch if multiple statements are to be executed atomically                                                                                     | No. While you can still use paging, it is irrelevant, because the result set of such operation is empty                                  |
 
-### Queries are fully asynchronous - you can run as many of them in parallel as you wish
+Executing statements is fully asynchronous, so they can be run in parallel without limitation.

--- a/docs/source/statements/unprepared.md
+++ b/docs/source/statements/unprepared.md
@@ -1,4 +1,4 @@
-# Unprepared statements
+# Unprepared Statements
 
 Whenever you want to execute statements without their prior preparation, you need to inform the driver what the inserted data is.
 There are multiple ways you can achieve that:


### PR DESCRIPTION
﻿## Summary

This PR reorganizes and improves the Node.js RS Driver documentation, applying feedback and adding new pages.

## Two commits

1. **`docs: update documentation moved from docs/src to docs/source`** - Updates to existing pages
2. **`docs: add new documentation pages`** - New Getting Started and Authentication pages

## Changes in existing pages

### All pages
- Driver name consistently changed to **Node.js RS Driver** throughout

### `statements/batch.md`
- Changed Warning to **Caution** (batch targeting different partitions)
- Updated unprepared batch warning to **Caution** with corrected wording
- Preserved `then` and `catch` callbacks with meaningful comments

### `statements/prepared.md`
- Changed unprepared batch `:::{warning}` to `:::{caution}`
- Fixed cache description: "its cache of prepared statements if available, or prepares the query before execution and keeps the prepared statement in its cache from now on"
- Changed "Paged vs Unpaged queries" to "Paged vs Unpaged statements" (statement terminology)
- Changed "Queries are fully asynchronous" to "Statements are fully asynchronous"

### `policies/load-balancing.md`
- Added: `DefaultLoadBalancingPolicy` is configured only at creation time
- Changed "You can set all, or only some of those options" to "You can set all or a subset of these options"
- Changed `### Datacenter Failover` to `#### Datacenter Failover`
- Added explicit DC failover behavior when `permitDcFailover` is false/true
- Expanded token awareness: "minimizes network traffic and maximizes locality, improving both throughput and latency"
- Added Token awareness Note block (requires prepared statements)
- Replaced Token awareness / Replica Shuffling sections with full content from feedback
- Expanded allow list: "any host not on the list is ignored, i.e., the driver does not open any connections to it"

### `paging/paging.md`
- Updated async iterator description: "fetching subsequent pages automatically as the previous one has been consumed"
- Updated "If there are additional rows" sentence per feedback
- Changed automatic paging bullet to bold format: **Automatic paging** (default)
- Preserved all required content: warning block, eachRow section, row streams, manual paging, code examples with comments

### `migration-guide/migration-guide.md`
- Fixed `id` option: corrected to state it continues to require a `Uuid` instance (not string/both)
- Added Shutdown behavior section with: deallocate structures, stop in-flight queries, GC lifecycle
- Added unprepared batch caution section
- Note that cassandra-driver was transferred to Apache

### `shutdown/shutdown.md`
- Added explicit bullet list: does not deallocate connection-related structures, does not stop in-flight queries
- Updated to mention "Client object is garbage collected"

### `index.rst`
- Renamed driver to "ScyllaDB Node.js RS Driver"
- Added `getting-started` and `connecting/authentication` to toctree
- Added Contents section with links to all pages

## New pages

### `getting-started/getting-started.md` (new)
- Note that driver is based on ScyllaDB Rust Driver with link
- Installation section
- Connecting to ScyllaDB section
- Executing a Statement section
- Full Example: Create Table and Insert Data (uses `NetworkTopologyStrategy`)
- Next Steps with links to other doc pages

### `connecting/authentication.md` (new)
- Username/password authentication
- SSL/TLS configuration table
- Combined auth + SSL example

Fixes DRIVER-639 
