### PR TITLE
doc: publish the documentation for the latest version

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -10,10 +10,10 @@ sys.path.insert(0, os.path.abspath("../_extensions"))
 # -- General configuration ------------------------------------------
 
 # Build documentation for the following tags and branches
-TAGS = []
+TAGS = ["v0.5.1"]
 BRANCHES = ["main"]
-LATEST_VERSION = "main"
-UNSTABLE_VERSIONS = []
+LATEST_VERSION = "v0.5.1"
+UNSTABLE_VERSIONS = ["main"]
 DEPRECATED_VERSIONS = []
 
 # Add any Sphinx extension module names here, as strings.


### PR DESCRIPTION
Enables publication of the documentation for version v0.5.1. As the driver is still in beta, it is sufficient to publish documentation only for the latest version.

Additionally, v0.5.1 is set as the latest stable version, and the documentation on the main branch is marked as unstable.