### PR TITLE
docs: complie ts inside js-doc script

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -43,7 +43,7 @@ clean:
 # Generate output commands
 .PHONY: jsdoc
 jsdoc:
-	cd .. && ./node_modules/.bin/tsc -p tsconfig.build.json --noEmitOnError false; npm run js-doc
+	cd .. && npm run js-doc
 	@echo
 	@echo "JSDoc build finished. The API docs are in ../public/docs/."
 

--- a/docs/_utils/multiversion.sh
+++ b/docs/_utils/multiversion.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 cd .. && sphinx-multiversion docs/source docs/_build/dirhtml \
-    --pre-build 'sh -c "npm install && (./node_modules/.bin/tsc -p tsconfig.build.json --noEmitOnError false || true) && npm run js-doc && python docs/_utils/generate_api_pages.py"'
+    --pre-build 'sh -c "npm install && npm run js-doc && python docs/_utils/generate_api_pages.py"'

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "prettier": "npx prettier \"{lib,examples,test}/**/*.{js,ts}\" --write",
     "full-clippy": "cargo clippy --all-targets --all-features -- -D warnings",
     "pre-push": "npm run prettier && cargo fmt && npm run full-clippy && napi build --platform && npm run eslint-fix",
-    "js-doc": "jsdoc ./lib -r -c js-doc-config.js",
+    "js-doc": "tsc -p tsconfig.build.json --noEmitOnError false; jsdoc ./lib -r -c js-doc-config.js",
     "artifacts": "napi artifacts",
     "create-npm-dirs": "napi create-npm-dirs",
     "build:debug": "napi build --platform",


### PR DESCRIPTION
## Problem

Multiversion is not publishing reference docs for .ts files.


## Fix

Compile ts too in multiversion, not only when building the preview locally.