### PR TITLE
docs: exclude package-private members from API reference

### DIFF
--- a/js-doc-config.js
+++ b/js-doc-config.js
@@ -4,5 +4,9 @@ module.exports = {
     plugins: ['plugins/markdown'],
     opts: {
         destination: "./public/docs",
+        // Exclude @package members from the public API documentation.
+        // JSDoc renders all access levels except @private by default, so we
+        // explicitly list the levels to render and leave "package" out.
+        access: ["public", "protected", "undefined"],
     }
 }


### PR DESCRIPTION
Closes https://github.com/scylladb/nodejs-rs-driver/issues/484

## How to test

1. Build the docs.
2. Open http://127.0.0.1:5500/api/Client/
3. Check there are no (package) members.