### PR TITLE
Draft: [DRIVER-790] Validate SELECT without FROM support

### DIFF
--- a/test/integration/supported/select-without-from-tests.js
+++ b/test/integration/supported/select-without-from-tests.js
@@ -1,0 +1,75 @@
+"use strict";
+const assert = require("assert");
+
+const helper = require("../../test-helper");
+const types = require("../../../lib/types");
+
+function getResponseCode(err) {
+    if (!err) {
+        return undefined;
+    }
+    if (typeof err.code === "number") {
+        return err.code;
+    }
+    if (err.innerErrors) {
+        return Object.keys(err.innerErrors)
+            .map((key) => getResponseCode(err.innerErrors[key]))
+            .find((code) => typeof code === "number");
+    }
+    return undefined;
+}
+
+function isSelectWithoutFromUnsupported(err) {
+    const code = getResponseCode(err);
+    return (
+        code === types.responseErrorCodes.syntaxError ||
+        code === types.responseErrorCodes.invalid ||
+        /select without from|mismatched input|no viable alternative|syntax error/i.test(
+            err.message || "",
+        )
+    );
+}
+
+function assertLiteralResult(result) {
+    assert.strictEqual(result.rows.length, 1);
+    assert.strictEqual(result.columns.length, 1);
+    assert.strictEqual(result.columns[0].name, "1");
+    assert.strictEqual(result.columns[0].type.code, types.dataTypes.int);
+    assert.strictEqual(result.rows[0].get(0), 1);
+}
+
+function assertNowResult(result) {
+    assert.strictEqual(result.rows.length, 1);
+    assert.strictEqual(result.columns.length, 1);
+    assert.strictEqual(result.columns[0].name, "now()");
+    assert.strictEqual(result.columns[0].type.code, types.dataTypes.timeuuid);
+    assert.ok(result.rows[0].get(0) instanceof types.TimeUuid);
+}
+
+describe("SELECT without FROM @SERVER_API", function () {
+    this.timeout(120000);
+
+    const setupInfo = helper.setup(1);
+
+    it("should execute simple and prepared queries", async function () {
+        const client = setupInfo.client;
+        let result;
+        try {
+            result = await client.execute("SELECT 1");
+        } catch (err) {
+            if (isSelectWithoutFromUnsupported(err)) {
+                this.skip();
+            }
+            throw err;
+        }
+
+        assertLiteralResult(result);
+        assertNowResult(await client.execute("SELECT now()"));
+        assertLiteralResult(
+            await client.execute("SELECT 1", [], { prepare: true }),
+        );
+        assertNowResult(
+            await client.execute("SELECT now()", [], { prepare: true }),
+        );
+    });
+});


### PR DESCRIPTION
Jira: https://scylladb.atlassian.net/browse/DRIVER-790
GitHub issue: https://github.com/scylladb/nodejs-rs-driver/issues/494
Parent epic: https://scylladb.atlassian.net/browse/DRIVER-782

Draft PR for validating SELECT without FROM support in this driver.

Refs #494.

Scope:
- Add or update integration tests for SELECT 1.
- Add or update integration tests for SELECT now().
- Cover prepared and non-prepared execution paths where relevant.
- Feature-detect or skip cleanly against servers that do not support SELECT without FROM.
- Document any driver-specific limitation found during implementation.

This draft currently contains an empty setup commit so work can start from a linked branch without adding placeholder source changes.