### PR TITLE
Add napi build to multiversion pre-build step

### DIFF
--- a/docs/_utils/multiversion.sh
+++ b/docs/_utils/multiversion.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 cd .. && sphinx-multiversion docs/source docs/_build/dirhtml \
-    --pre-build 'sh -c "npm install && npm run js-doc && python docs/_utils/generate_api_pages.py"'
+    --pre-build 'sh -c "npm install && npm run build && npm run js-doc && python docs/_utils/generate_api_pages.py"'


### PR DESCRIPTION
`docs/_utils/multiversion.sh` ran `npm install && npm run js-doc` as the pre-build step. However, `index.d.ts` and `index.js` are NAPI-RS-generated build artifacts that are gitignored. We need to run napi build locally so tcs can find `index.d.ts` and resolve it.