### PR TITLE
Redesign of Metadata API

### DIFF
--- a/lib/client-options.js
+++ b/lib/client-options.js
@@ -70,16 +70,6 @@ const { ExecutionProfile } = require("./execution-profile.js");
  * @property {Number} [refreshSchemaDelay] The default window size in milliseconds used to debounce node list and schema
  * refresh metadata requests. Default: 1000.
  * [TODO: Add support for this field]
- * @property {Boolean} [isMetadataSyncEnabled] Determines whether client-side schema metadata retrieval and update is
- * enabled.
- *
- * Setting this value to `false` will cause keyspace information not to be automatically loaded, affecting
- * replica calculation per token in the different keyspaces. When disabling metadata synchronization, use
- * [Metadata.refreshKeyspaces()]{@link module:metadata~Metadata#refreshKeyspaces} to keep keyspace information up to
- * date or token-awareness will not work correctly.
- *
- * Default: `true`.
- * [TODO: Add support for this field]
  * @property {Boolean} [prepareOnAllHosts] Determines if the driver should prepare queries on all hosts in the cluster.
  * Default: `true`.
  * [TODO: Add support for this field]
@@ -473,7 +463,6 @@ function defaultOptions() {
         metrics: new metrics.DefaultMetrics(),
         maxPrepared: null, // Default is 512, defined on the Rust side
         refreshSchemaDelay: 1000,
-        isMetadataSyncEnabled: true,
         prepareOnAllHosts: true,
         rePrepareOnUp: true,
         encoding: {

--- a/lib/metadata/index.d.ts
+++ b/lib/metadata/index.d.ts
@@ -146,6 +146,44 @@ export interface Metadata {
 
   clearPrepared(): void;
 
+  refreshKeyspace(name: string, callback: EmptyCallback): void;
+
+  refreshKeyspace(name: string): Promise<void>;
+
+  refreshKeyspaces(waitReconnect: boolean, callback: EmptyCallback): void;
+
+  refreshKeyspaces(waitReconnect?: boolean): Promise<void>;
+
+  refreshKeyspaces(callback: EmptyCallback): void;
+
+  getTable(
+    keyspaceName: string,
+    name: string,
+    callback: ValueCallback<TableMetadata>,
+  ): void;
+
+  getTable(keyspaceName: string, name: string): Promise<TableMetadata>;
+
+  getMaterializedView(
+    keyspaceName: string,
+    name: string,
+    callback: ValueCallback<MaterializedView>,
+  ): void;
+
+  getMaterializedView(
+    keyspaceName: string,
+    name: string,
+    callback: EmptyCallback,
+  ): Promise<MaterializedView>;
+
+  getUdt(
+    keyspaceName: string,
+    name: string,
+    callback: ValueCallback<Udt>,
+  ): void;
+
+  getUdt(keyspaceName: string, name: string): Promise<Udt>;
+
   getAggregate(
     keyspaceName: string,
     name: string,
@@ -188,38 +226,6 @@ export interface Metadata {
 
   getFunctions(keyspaceName: string, name: string): Promise<SchemaFunction[]>;
 
-  getMaterializedView(
-    keyspaceName: string,
-    name: string,
-    callback: ValueCallback<MaterializedView>,
-  ): void;
-
-  getMaterializedView(
-    keyspaceName: string,
-    name: string,
-    callback: EmptyCallback,
-  ): Promise<MaterializedView>;
-
-  getReplicas(
-    keyspaceName: string,
-    token: Buffer | token.Token | token.TokenRange,
-  ): Host[];
-
-  getTable(
-    keyspaceName: string,
-    name: string,
-    callback: ValueCallback<TableMetadata>,
-  ): void;
-
-  getTable(keyspaceName: string, name: string): Promise<TableMetadata>;
-
-  getTokenRanges(): Set<token.TokenRange>;
-
-  getTokenRangesForHost(
-    keyspaceName: string,
-    host: Host,
-  ): Set<token.TokenRange> | null;
-
   getTrace(
     traceId: Uuid,
     consistency: types.consistencies,
@@ -235,25 +241,19 @@ export interface Metadata {
 
   getTrace(traceId: Uuid): Promise<QueryTrace>;
 
-  getUdt(
+  getReplicas(
     keyspaceName: string,
-    name: string,
-    callback: ValueCallback<Udt>,
-  ): void;
+    token: Buffer | token.Token | token.TokenRange,
+  ): Host[];
 
-  getUdt(keyspaceName: string, name: string): Promise<Udt>;
+  getTokenRanges(): Set<token.TokenRange>;
+
+  getTokenRangesForHost(
+    keyspaceName: string,
+    host: Host,
+  ): Set<token.TokenRange> | null;
 
   newToken(components: Buffer[] | Buffer | string): token.Token;
 
   newTokenRange(start: token.Token, end: token.Token): token.TokenRange;
-
-  refreshKeyspace(name: string, callback: EmptyCallback): void;
-
-  refreshKeyspace(name: string): Promise<void>;
-
-  refreshKeyspaces(waitReconnect: boolean, callback: EmptyCallback): void;
-
-  refreshKeyspaces(waitReconnect?: boolean): Promise<void>;
-
-  refreshKeyspaces(callback: EmptyCallback): void;
 }

--- a/lib/metadata/index.d.ts
+++ b/lib/metadata/index.d.ts
@@ -5,255 +5,255 @@ import Uuid = types.Uuid;
 import InetAddress = types.InetAddress;
 
 export interface Aggregate {
-    argumentTypes: Array<{ code: dataTypes; info: any }>;
-    finalFunction: string;
-    initCondition: string;
-    keyspaceName: string;
-    returnType: string;
-    signature: string[];
-    stateFunction: string;
-    stateType: string;
-  }
+  argumentTypes: Array<{ code: dataTypes; info: any }>;
+  finalFunction: string;
+  initCondition: string;
+  keyspaceName: string;
+  returnType: string;
+  signature: string[];
+  stateFunction: string;
+  stateType: string;
+}
 
 export interface ClientState {
-    getConnectedHosts(): Host[];
+  getConnectedHosts(): Host[];
 
-    getInFlightQueries(host: Host): number;
+  getInFlightQueries(host: Host): number;
 
-    getOpenConnections(host: Host): number;
+  getOpenConnections(host: Host): number;
 
-    toString(): string;
-  }
+  toString(): string;
+}
 
 export interface DataTypeInfo {
-    code: dataTypes;
-    info: string | DataTypeInfo | DataTypeInfo[];
-    options: {
-      frozen: boolean;
-      reversed: boolean;
-    };
-  }
+  code: dataTypes;
+  info: string | DataTypeInfo | DataTypeInfo[];
+  options: {
+    frozen: boolean;
+    reversed: boolean;
+  };
+}
 
 export interface ColumnInfo {
-    name: string;
-    type: DataTypeInfo;
-  }
+  name: string;
+  type: DataTypeInfo;
+}
 
 export enum ColumnKind {
-    Regular = 0,
-    Static = 1,
-    ClusteringKey = 2,
-    PartitionKey = 3,
-  }
+  Regular = 0,
+  Static = 1,
+  ClusteringKey = 2,
+  PartitionKey = 3,
+}
 
 export interface ColumnMetadata {
-    type: string;
-    kind: ColumnKind;
-  }
+  type: string;
+  kind: ColumnKind;
+}
 
 export enum IndexKind {
-    custom = 0,
-    keys,
-    composites,
-  }
+  custom = 0,
+  keys,
+  composites,
+}
 
 export interface Index {
-    kind: IndexKind;
-    name: string;
-    options: object;
-    target: string;
+  kind: IndexKind;
+  name: string;
+  options: object;
+  target: string;
 
-    isCompositesKind(): boolean;
+  isCompositesKind(): boolean;
 
-    isCustomKind(): boolean;
+  isCustomKind(): boolean;
 
-    isKeysKind(): boolean;
-  }
+  isKeysKind(): boolean;
+}
 
 export interface MaterializedView extends TableMetadata {
-    tableName: string;
-  }
+  tableName: string;
+}
 
 export interface TableMetadata {
-    columns: { [name: string]: ColumnMetadata };
-    partitionKey: string[];
-    clusteringKey: string[];
-    partitioner: string | null;
-  }
+  columns: { [name: string]: ColumnMetadata };
+  partitionKey: string[];
+  clusteringKey: string[];
+  partitioner: string | null;
+}
 
 export interface QueryTrace {
-    requestType: string;
-    coordinator: InetAddress;
-    parameters: { [key: string]: any };
-    startedAt: number | types.Long;
-    duration: number;
-    clientAddress: string;
-    events: Array<{
-      id: Uuid;
-      activity: any;
-      source: any;
-      elapsed: any;
-      thread: any;
-    }>;
-  }
+  requestType: string;
+  coordinator: InetAddress;
+  parameters: { [key: string]: any };
+  startedAt: number | types.Long;
+  duration: number;
+  clientAddress: string;
+  events: Array<{
+    id: Uuid;
+    activity: any;
+    source: any;
+    elapsed: any;
+    thread: any;
+  }>;
+}
 
 export interface SchemaFunction {
-    argumentNames: string[];
-    argumentTypes: Array<{ code: dataTypes; info: any }>;
-    body: string;
-    calledOnNullInput: boolean;
-    keyspaceName: string;
-    language: string;
-    name: string;
-    returnType: string;
-    signature: string[];
-  }
+  argumentNames: string[];
+  argumentTypes: Array<{ code: dataTypes; info: any }>;
+  body: string;
+  calledOnNullInput: boolean;
+  keyspaceName: string;
+  language: string;
+  name: string;
+  returnType: string;
+  signature: string[];
+}
 
 export interface UdtField {
-    name: string;
-    type: DataTypeInfo;
-  }
+  name: string;
+  type: DataTypeInfo;
+}
 
 export interface Udt {
-    name: string;
-    keyspace: string;
-    fields: UdtField[];
-  }
+  name: string;
+  keyspace: string;
+  fields: UdtField[];
+}
 
 export enum StrategyKind {
-    SimpleStrategy = 0,
-    NetworkTopologyStrategy = 1,
-    LocalStrategy = 2,
-    Other = 3,
-  }
+  SimpleStrategy = 0,
+  NetworkTopologyStrategy = 1,
+  LocalStrategy = 2,
+  Other = 3,
+}
 
 export type Strategy =
-    | { kind: StrategyKind.SimpleStrategy; replicationFactor: number }
-    | { kind: StrategyKind.NetworkTopologyStrategy; datacenterRepfactors: { [datacenter: string]: number } }
-    | { kind: StrategyKind.LocalStrategy }
-    | { kind: StrategyKind.Other; name: string; data: { [key: string]: string } };
+  | { kind: StrategyKind.SimpleStrategy; replicationFactor: number }
+  | { kind: StrategyKind.NetworkTopologyStrategy; datacenterRepfactors: { [datacenter: string]: number } }
+  | { kind: StrategyKind.LocalStrategy }
+  | { kind: StrategyKind.Other; name: string; data: { [key: string]: string } };
 
 export interface KeyspaceMetadata {
-    strategy: Strategy;
-    durableWrites: boolean;
-    tables: { [name: string]: TableMetadata };
-    views: { [name: string]: MaterializedView };
-    userDefinedTypes: { [name: string]: Udt };
-  }
+  strategy: Strategy;
+  durableWrites: boolean;
+  tables: { [name: string]: TableMetadata };
+  views: { [name: string]: MaterializedView };
+  userDefinedTypes: { [name: string]: Udt };
+}
 
 export interface Metadata {
-    keyspaces: { [name: string]: { name: string; strategy: string } };
+  keyspaces: { [name: string]: { name: string; strategy: string } };
 
-    clearPrepared(): void;
+  clearPrepared(): void;
 
-    getAggregate(
-      keyspaceName: string,
-      name: string,
-      signature: string[] | Array<{ code: number; info: any }>,
-      callback: ValueCallback<Aggregate>,
-    ): void;
+  getAggregate(
+    keyspaceName: string,
+    name: string,
+    signature: string[] | Array<{ code: number; info: any }>,
+    callback: ValueCallback<Aggregate>,
+  ): void;
 
-    getAggregate(
-      keyspaceName: string,
-      name: string,
-      signature: string[] | Array<{ code: number; info: any }>,
-    ): Promise<Aggregate>;
+  getAggregate(
+    keyspaceName: string,
+    name: string,
+    signature: string[] | Array<{ code: number; info: any }>,
+  ): Promise<Aggregate>;
 
-    getAggregates(
-      keyspaceName: string,
-      name: string,
-      callback: ValueCallback<Aggregate[]>,
-    ): void;
+  getAggregates(
+    keyspaceName: string,
+    name: string,
+    callback: ValueCallback<Aggregate[]>,
+  ): void;
 
-    getAggregates(keyspaceName: string, name: string): Promise<Aggregate[]>;
+  getAggregates(keyspaceName: string, name: string): Promise<Aggregate[]>;
 
-    getFunction(
-      keyspaceName: string,
-      name: string,
-      signature: string[] | Array<{ code: number; info: any }>,
-      callback: ValueCallback<SchemaFunction>,
-    ): void;
+  getFunction(
+    keyspaceName: string,
+    name: string,
+    signature: string[] | Array<{ code: number; info: any }>,
+    callback: ValueCallback<SchemaFunction>,
+  ): void;
 
-    getFunction(
-      keyspaceName: string,
-      name: string,
-      signature: string[] | Array<{ code: number; info: any }>,
-    ): Promise<SchemaFunction>;
+  getFunction(
+    keyspaceName: string,
+    name: string,
+    signature: string[] | Array<{ code: number; info: any }>,
+  ): Promise<SchemaFunction>;
 
-    getFunctions(
-      keyspaceName: string,
-      name: string,
-      callback: ValueCallback<SchemaFunction[]>,
-    ): void;
+  getFunctions(
+    keyspaceName: string,
+    name: string,
+    callback: ValueCallback<SchemaFunction[]>,
+  ): void;
 
-    getFunctions(keyspaceName: string, name: string): Promise<SchemaFunction[]>;
+  getFunctions(keyspaceName: string, name: string): Promise<SchemaFunction[]>;
 
-    getMaterializedView(
-      keyspaceName: string,
-      name: string,
-      callback: ValueCallback<MaterializedView>,
-    ): void;
+  getMaterializedView(
+    keyspaceName: string,
+    name: string,
+    callback: ValueCallback<MaterializedView>,
+  ): void;
 
-    getMaterializedView(
-      keyspaceName: string,
-      name: string,
-      callback: EmptyCallback,
-    ): Promise<MaterializedView>;
+  getMaterializedView(
+    keyspaceName: string,
+    name: string,
+    callback: EmptyCallback,
+  ): Promise<MaterializedView>;
 
-    getReplicas(
-      keyspaceName: string,
-      token: Buffer | token.Token | token.TokenRange,
-    ): Host[];
+  getReplicas(
+    keyspaceName: string,
+    token: Buffer | token.Token | token.TokenRange,
+  ): Host[];
 
-    getTable(
-      keyspaceName: string,
-      name: string,
-      callback: ValueCallback<TableMetadata>,
-    ): void;
+  getTable(
+    keyspaceName: string,
+    name: string,
+    callback: ValueCallback<TableMetadata>,
+  ): void;
 
-    getTable(keyspaceName: string, name: string): Promise<TableMetadata>;
+  getTable(keyspaceName: string, name: string): Promise<TableMetadata>;
 
-    getTokenRanges(): Set<token.TokenRange>;
+  getTokenRanges(): Set<token.TokenRange>;
 
-    getTokenRangesForHost(
-      keyspaceName: string,
-      host: Host,
-    ): Set<token.TokenRange> | null;
+  getTokenRangesForHost(
+    keyspaceName: string,
+    host: Host,
+  ): Set<token.TokenRange> | null;
 
-    getTrace(
-      traceId: Uuid,
-      consistency: types.consistencies,
-      callback: ValueCallback<QueryTrace>,
-    ): void;
+  getTrace(
+    traceId: Uuid,
+    consistency: types.consistencies,
+    callback: ValueCallback<QueryTrace>,
+  ): void;
 
-    getTrace(
-      traceId: Uuid,
-      consistency: types.consistencies,
-    ): Promise<QueryTrace>;
+  getTrace(
+    traceId: Uuid,
+    consistency: types.consistencies,
+  ): Promise<QueryTrace>;
 
-    getTrace(traceId: Uuid, callback: ValueCallback<QueryTrace>): void;
+  getTrace(traceId: Uuid, callback: ValueCallback<QueryTrace>): void;
 
-    getTrace(traceId: Uuid): Promise<QueryTrace>;
+  getTrace(traceId: Uuid): Promise<QueryTrace>;
 
-    getUdt(
-      keyspaceName: string,
-      name: string,
-      callback: ValueCallback<Udt>,
-    ): void;
+  getUdt(
+    keyspaceName: string,
+    name: string,
+    callback: ValueCallback<Udt>,
+  ): void;
 
-    getUdt(keyspaceName: string, name: string): Promise<Udt>;
+  getUdt(keyspaceName: string, name: string): Promise<Udt>;
 
-    newToken(components: Buffer[] | Buffer | string): token.Token;
+  newToken(components: Buffer[] | Buffer | string): token.Token;
 
-    newTokenRange(start: token.Token, end: token.Token): token.TokenRange;
+  newTokenRange(start: token.Token, end: token.Token): token.TokenRange;
 
-    refreshKeyspace(name: string, callback: EmptyCallback): void;
+  refreshKeyspace(name: string, callback: EmptyCallback): void;
 
-    refreshKeyspace(name: string): Promise<void>;
+  refreshKeyspace(name: string): Promise<void>;
 
-    refreshKeyspaces(waitReconnect: boolean, callback: EmptyCallback): void;
+  refreshKeyspaces(waitReconnect: boolean, callback: EmptyCallback): void;
 
-    refreshKeyspaces(waitReconnect?: boolean): Promise<void>;
+  refreshKeyspaces(waitReconnect?: boolean): Promise<void>;
 
-    refreshKeyspaces(callback: EmptyCallback): void;
-  }
+  refreshKeyspaces(callback: EmptyCallback): void;
+}

--- a/lib/metadata/index.d.ts
+++ b/lib/metadata/index.d.ts
@@ -144,100 +144,48 @@ export interface KeyspaceMetadata {
 export interface Metadata {
   keyspaces: { [name: string]: { name: string; strategy: string } };
 
-  refreshKeyspace(name: string, callback: EmptyCallback): void;
+  refreshKeyspace(name: string): void;
 
-  refreshKeyspace(name: string): Promise<void>;
-
-  refreshKeyspaces(waitReconnect: boolean, callback: EmptyCallback): void;
-
-  refreshKeyspaces(waitReconnect?: boolean): Promise<void>;
-
-  refreshKeyspaces(callback: EmptyCallback): void;
+  refreshKeyspaces(waitReconnect?: boolean): void;
 
   getTable(
     keyspaceName: string,
     name: string,
-    callback: ValueCallback<TableMetadata>,
-  ): void;
-
-  getTable(keyspaceName: string, name: string): Promise<TableMetadata>;
+  ): TableMetadata | null;
 
   getMaterializedView(
     keyspaceName: string,
     name: string,
-    callback: ValueCallback<MaterializedView>,
-  ): void;
+  ): MaterializedView | null;
 
-  getMaterializedView(
-    keyspaceName: string,
-    name: string,
-    callback: EmptyCallback,
-  ): Promise<MaterializedView>;
-
-  getUdt(
-    keyspaceName: string,
-    name: string,
-    callback: ValueCallback<Udt>,
-  ): void;
-
-  getUdt(keyspaceName: string, name: string): Promise<Udt>;
+  getUdt(keyspaceName: string, name: string): Udt | null;
 
   getAggregate(
     keyspaceName: string,
     name: string,
     signature: string[] | Array<{ code: number; info: any }>,
-    callback: ValueCallback<Aggregate>,
-  ): void;
-
-  getAggregate(
-    keyspaceName: string,
-    name: string,
-    signature: string[] | Array<{ code: number; info: any }>,
-  ): Promise<Aggregate>;
+  ): Aggregate | null;
 
   getAggregates(
     keyspaceName: string,
     name: string,
-    callback: ValueCallback<Aggregate[]>,
-  ): void;
-
-  getAggregates(keyspaceName: string, name: string): Promise<Aggregate[]>;
+  ): Aggregate[];
 
   getFunction(
     keyspaceName: string,
     name: string,
     signature: string[] | Array<{ code: number; info: any }>,
-    callback: ValueCallback<SchemaFunction>,
-  ): void;
-
-  getFunction(
-    keyspaceName: string,
-    name: string,
-    signature: string[] | Array<{ code: number; info: any }>,
-  ): Promise<SchemaFunction>;
+  ): SchemaFunction | null;
 
   getFunctions(
     keyspaceName: string,
     name: string,
-    callback: ValueCallback<SchemaFunction[]>,
-  ): void;
-
-  getFunctions(keyspaceName: string, name: string): Promise<SchemaFunction[]>;
+  ): SchemaFunction[];
 
   getTrace(
     traceId: Uuid,
-    consistency: types.consistencies,
-    callback: ValueCallback<QueryTrace>,
-  ): void;
-
-  getTrace(
-    traceId: Uuid,
-    consistency: types.consistencies,
-  ): Promise<QueryTrace>;
-
-  getTrace(traceId: Uuid, callback: ValueCallback<QueryTrace>): void;
-
-  getTrace(traceId: Uuid): Promise<QueryTrace>;
+    consistency?: types.consistencies,
+  ): QueryTrace | null;
 
   getReplicas(
     keyspaceName: string,

--- a/lib/metadata/index.d.ts
+++ b/lib/metadata/index.d.ts
@@ -142,11 +142,9 @@ export interface KeyspaceMetadata {
 }
 
 export interface Metadata {
-  keyspaces: { [name: string]: { name: string; strategy: string } };
+  getKeyspace(name: string): KeyspaceMetadata | null;
 
-  refreshKeyspace(name: string): void;
-
-  refreshKeyspaces(waitReconnect?: boolean): void;
+  getKeyspaces(): Map<string, KeyspaceMetadata>;
 
   getTable(
     keyspaceName: string,

--- a/lib/metadata/index.d.ts
+++ b/lib/metadata/index.d.ts
@@ -200,4 +200,6 @@ export interface Metadata {
   newToken(components: Buffer[] | Buffer | string): token.Token;
 
   newTokenRange(start: token.Token, end: token.Token): token.TokenRange;
+
+  checkSchemaAgreement(): Boolean;
 }

--- a/lib/metadata/index.d.ts
+++ b/lib/metadata/index.d.ts
@@ -138,7 +138,7 @@ export interface KeyspaceMetadata {
   durableWrites: boolean;
   tables: { [name: string]: TableMetadata };
   views: { [name: string]: MaterializedView };
-  userDefinedTypes: { [name: string]: Udt };
+  udts: { [name: string]: Udt };
 }
 
 export interface Metadata {

--- a/lib/metadata/index.d.ts
+++ b/lib/metadata/index.d.ts
@@ -144,8 +144,6 @@ export interface KeyspaceMetadata {
 export interface Metadata {
   keyspaces: { [name: string]: { name: string; strategy: string } };
 
-  clearPrepared(): void;
-
   refreshKeyspace(name: string, callback: EmptyCallback): void;
 
   refreshKeyspace(name: string): Promise<void>;

--- a/lib/metadata/index.js
+++ b/lib/metadata/index.js
@@ -52,25 +52,25 @@ class Metadata {
     }
 
     /**
-     * Gets the keyspace metadata information and updates the internal state of the driver.
+     * Gets the keyspace metadata by name.
      * @param {String} name Name of the keyspace.
+     * @returns {KeyspaceMetadata | null} The keyspace metadata, or `null` if it does not exist.
      */
-    refreshKeyspace(name) {
+    getKeyspace(name) {
         throw new Error("TODO: Not implemented");
     }
 
     /**
-     * Gets the metadata information of all the keyspaces and updates the internal state of the driver.
-     * @param {Boolean} [waitReconnect] Determines if it should wait for reconnection in case the control connection is not
-     * connected at the moment. Default: true.
+     * Gets all keyspace metadata.
+     * @returns {Map<string, KeyspaceMetadata>} A map of all keyspaces indexed by name.
      */
-    refreshKeyspaces(waitReconnect) {
+    getKeyspaces() {
         throw new Error("TODO: Not implemented");
     }
 
     /**
      * Gets the host list representing the replicas that contain the given partition key, token or token range.
-     * 
+     *
      * It uses the pre-loaded keyspace metadata to retrieve the replicas for a token for a given keyspace.
      * When the keyspace metadata has not been loaded, it returns null.
      * @param {String} keyspaceName

--- a/lib/metadata/index.js
+++ b/lib/metadata/index.js
@@ -53,7 +53,7 @@ class Metadata {
 
     /**
      * Gets the keyspace metadata by name.
-     * @param {String} name Name of the keyspace.
+     * @param {string} name Name of the keyspace.
      * @returns {KeyspaceMetadata | null} The keyspace metadata, or `null` if it does not exist.
      */
     getKeyspace(name) {
@@ -73,9 +73,9 @@ class Metadata {
      *
      * It uses the pre-loaded keyspace metadata to retrieve the replicas for a token for a given keyspace.
      * When the keyspace metadata has not been loaded, it returns null.
-     * @param {String} keyspaceName
-     * @param {Buffer|Token|TokenRange} token Can be Buffer (serialized partition key), Token or TokenRange
-     * @returns {Array<any>}
+     * @param {string} keyspaceName Name of the keyspace.
+     * @param {Buffer | Token | TokenRange} token Can be Buffer (serialized partition key), Token or TokenRange.
+     * @returns {Array<Host>}.
      */
     getReplicas(keyspaceName, token) {
         throw new Error("TODO: Not implemented");
@@ -90,20 +90,20 @@ class Metadata {
     }
 
     /**
-     * Gets the token ranges that are replicated on the given host, for
-     * the given keyspace.
-     * @param {String} keyspaceName The name of the keyspace to get ranges for.
+     * Gets the token ranges that are replicated on the given host, for the given keyspace.
+     * @param {string} keyspaceName The name of the keyspace to get ranges for.
      * @param {Host} host The host.
-     * @returns {Set<TokenRange>|null} Ranges for the keyspace on this host or null if keyspace isn't found or hasn't been loaded.
+     * @returns {Set<TokenRange> | null} Ranges for the keyspace on this host or null if keyspace
+     * isn't found or hasn't been loaded.
      */
     getTokenRangesForHost(keyspaceName, host) {
         throw new Error("TODO: Not implemented");
     }
 
     /**
-     * Constructs a Token from the input buffer(s) or string input.  If a string is passed in
+     * Constructs a Token from the input buffer(s) or string input. If a string is passed in
      * it is assumed this matches the token representation reported by cassandra.
-     * @param {Array<Buffer>|Buffer|String} components
+     * @param {Array<Buffer> | Buffer | string} components The token components.
      * @returns {Token} constructed token from the input buffer.
      */
     newToken(components) {
@@ -112,9 +112,9 @@ class Metadata {
 
     /**
      * Constructs a TokenRange from the given start and end tokens.
-     * @param {Token} start
-     * @param {Token} end
-     * @returns TokenRange build range spanning from start (exclusive) to end (inclusive).
+     * @param {Token} start The start token.
+     * @param {Token} end The end token.
+     * @returns {TokenRange} build range spanning from start (exclusive) to end (inclusive).
      */
     newTokenRange(start, end) {
         throw new Error("TODO: Not implemented");
@@ -122,8 +122,9 @@ class Metadata {
 
     /**
      * Gets the definition of an user-defined type.
-     * @param {String} keyspaceName Name of the keyspace.
-     * @param {String} name Name of the UDT.
+     * @param {string} keyspaceName Name of the keyspace.
+     * @param {string} name Name of the UDT.
+     * @returns {Udt | null} The UDT definition, or `null` if it does not exist.
      */
     getUdt(keyspaceName, name) {
         throw new Error("TODO: Not implemented");
@@ -131,8 +132,9 @@ class Metadata {
 
     /**
      * Gets the definition of a table.
-     * @param {String} keyspaceName Name of the keyspace.
-     * @param {String} name Name of the Table.
+     * @param {string} keyspaceName Name of the keyspace.
+     * @param {string} name Name of the Table.
+     * @returns {TableMetadata | null} The table metadata, or `null` if it does not exist.
      */
     getTable(keyspaceName, name) {
         throw new Error("TODO: Not implemented");
@@ -140,8 +142,9 @@ class Metadata {
 
     /**
      * Gets the definition of CQL functions for a given name.
-     * @param {String} keyspaceName Name of the keyspace.
-     * @param {String} name Name of the Function.
+     * @param {string} keyspaceName Name of the keyspace.
+     * @param {string} name Name of the Function.
+     * @returns {Array<SchemaFunction>} An array of schema function metadata.
      */
     getFunctions(keyspaceName, name) {
         throw new Error("TODO: Not implemented");
@@ -149,9 +152,10 @@ class Metadata {
 
     /**
      * Gets a definition of CQL function for a given name and signature.
-     * @param {String} keyspaceName Name of the keyspace
-     * @param {String} name Name of the Function
-     * @param {Array.<String>|Array.<{code, info}>} signature Array of types of the parameters.
+     * @param {string} keyspaceName Name of the keyspace.
+     * @param {string} name Name of the Function.
+     * @param {Array<string> | Array<{code, info}>} signature Array of types of the parameters.
+     * @returns {SchemaFunction | null} The schema function metadata, or `null` if it does not exist.
      */
     getFunction(keyspaceName, name, signature) {
         throw new Error("TODO: Not implemented");
@@ -159,8 +163,9 @@ class Metadata {
 
     /**
      * Gets the definition of CQL aggregate for a given name.
-     * @param {String} keyspaceName Name of the keyspace
-     * @param {String} name Name of the aggregate
+     * @param {string} keyspaceName Name of the keyspace.
+     * @param {string} name Name of the aggregate.
+     * @returns {Array<Aggregate>} An array of schema aggregate metadata.
      */
     getAggregates(keyspaceName, name) {
         throw new Error("TODO: Not implemented");
@@ -168,9 +173,10 @@ class Metadata {
 
     /**
      * Gets a definition of CQL aggregate for a given name and signature.
-     * @param {String} keyspaceName Name of the keyspace
-     * @param {String} name Name of the aggregate
-     * @param {Array.<String>|Array.<{code, info}>} signature Array of types of the parameters.
+     * @param {string} keyspaceName Name of the keyspace.
+     * @param {string} name Name of the aggregate.
+     * @param {Array<string> | Array<{code, info}>} signature Array of types of the parameters.
+     * @returns {Aggregate | null} The schema aggregate metadata, or `null` if it does not exist.
      */
     getAggregate(keyspaceName, name, signature) {
         throw new Error("TODO: Not implemented");
@@ -182,8 +188,9 @@ class Metadata {
      * Note that, unlike the rest of the {@link Metadata} methods, this method does not cache the result for following
      * calls, as the current version of the Cassandra native protocol does not support schema change events for
      * materialized views. Each call to this method will produce one or more queries to the cluster.
-     * @param {String} keyspaceName Name of the keyspace
-     * @param {String} name Name of the materialized view
+     * @param {string} keyspaceName Name of the keyspace
+     * @param {string} name Name of the materialized view
+     * @returns {MaterializedView | null} The materialized view definition, or `null` if it does not exist.
      */
     getMaterializedView(keyspaceName, name) {
         throw new Error("TODO: Not implemented");

--- a/lib/metadata/index.js
+++ b/lib/metadata/index.js
@@ -121,14 +121,6 @@ class Metadata {
     }
 
     /**
-     * Clears the internal state related to the prepared statements.
-     * Following calls to the Client using the prepare flag will re-prepare the statements.
-     */
-    clearPrepared() {
-        throw new Error("TODO: Not implemented");
-    }
-
-    /**
      * Gets the definition of an user-defined type.
      * @param {String} keyspaceName Name of the keyspace.
      * @param {String} name Name of the UDT.

--- a/lib/metadata/keyspace-metadata.js
+++ b/lib/metadata/keyspace-metadata.js
@@ -7,7 +7,7 @@ const { TableMetadata } = require("./table-metadata");
 // eslint-disable-next-line no-unused-vars
 const { MaterializedView } = require("./materialized-view");
 // eslint-disable-next-line no-unused-vars
-const { UserDefinedType } = require("./user-defined-type");
+const { Udt } = require("./user-defined-type");
 
 /**
  * Identifies the replication strategy variant.
@@ -118,9 +118,9 @@ class KeyspaceMetadata {
 
     /**
      * User-defined types in the keyspace, keyed by type name.
-     * @type {Object.<String, UserDefinedType>}
+     * @type {Object.<String, Udt>}
      */
-    userDefinedTypes;
+    udts;
 }
 
 module.exports = { KeyspaceMetadata, Strategy, StrategyKind };

--- a/lib/metadata/user-defined-type.js
+++ b/lib/metadata/user-defined-type.js
@@ -25,9 +25,9 @@ class UdtField {
 
 /**
  * Describes a user-defined type (UDT) in the cluster.
- * @alias module:metadata~UserDefinedType
+ * @alias module:metadata~Udt
  */
-class UserDefinedType {
+class Udt {
     /**
      * Definition of a user-defined type (UDT).
      * UDT is composed of fields, each with a name and an optional value of its own type.
@@ -48,4 +48,4 @@ class UserDefinedType {
     fields;
 }
 
-module.exports = { UserDefinedType, UdtField };
+module.exports = { Udt, UdtField };

--- a/lib/types/cql-utils.ts
+++ b/lib/types/cql-utils.ts
@@ -130,7 +130,7 @@ export function convertComplexType(type: ComplexType): ColumnInfo {
                     [convertComplexType(type.subtype1), type.dimensions],
                     "vector",
                 );
-            case CqlType.UserDefinedType:
+            case CqlType.Udt:
                 return new ColumnInfo(type.baseType.valueOf(), {
                     name: type.name,
                     fields: type.udt_types.map(

--- a/main.d.ts
+++ b/main.d.ts
@@ -244,7 +244,6 @@ export interface ClientOptions {
     useBigIntAsLong?: boolean;
     useBigIntAsVarint?: boolean;
   };
-  isMetadataSyncEnabled?: boolean;
   maxPrepared?: number;
   metrics?: metrics.ClientMetrics;
   policies?: {

--- a/src/custom-types.d.ts
+++ b/src/custom-types.d.ts
@@ -11,11 +11,11 @@
  * This type represents the guarantees, that the value returned from Rust promises to have.
  */
 export type ComplexType =
-  | { baseType: Exclude<CqlType, CqlType.List | CqlType.Set | CqlType.Map | CqlType.Vector | CqlType.UserDefinedType | CqlType.Tuple> }
+  | { baseType: Exclude<CqlType, CqlType.List | CqlType.Set | CqlType.Map | CqlType.Vector | CqlType.Udt | CqlType.Tuple> }
   | { baseType: CqlType.List | CqlType.Set; frozen: boolean; subtype1: ComplexType }
   | { baseType: CqlType.Map; frozen: boolean; subtype1: ComplexType; subtype2: ComplexType }
   | { baseType: CqlType.Vector; subtype1: ComplexType; dimensions: number }
-  | { baseType: CqlType.UserDefinedType; frozen: boolean; name: string; keyspace: string; udt_types: ComplexType[]; udt_name: string[] }
+  | { baseType: CqlType.Udt; frozen: boolean; name: string; keyspace: string; udt_types: ComplexType[]; udt_name: string[] }
   | { baseType: CqlType.Tuple; subtypes: ComplexType[] }
 
 /**

--- a/src/types/type_wrappers.rs
+++ b/src/types/type_wrappers.rs
@@ -29,7 +29,7 @@ pub enum CqlType {
     List = 0x0020,
     Map = 0x0021,
     Set = 0x0022,
-    UserDefinedType = 0x0030,
+    Udt = 0x0030,
     SmallInt = 0x0013,
     TinyInt = 0x0014,
     Time = 0x0012,
@@ -142,7 +142,7 @@ impl ToNapiValue for ComplexType<'_> {
                 obj.set_named_property("dimensions", dimensions)?;
             }
             ColumnType::UserDefinedType { frozen, definition } => {
-                obj.set_named_property(base_type_name, CqlType::UserDefinedType)?;
+                obj.set_named_property(base_type_name, CqlType::Udt)?;
                 obj.set_named_property("frozen", frozen)?;
                 obj.set_named_property("name", definition.name.as_ref())?;
                 obj.set_named_property("keyspace", definition.keyspace.as_ref())?;

--- a/test/integration/broken/client-metadata-tests-long.js
+++ b/test/integration/broken/client-metadata-tests-long.js
@@ -54,8 +54,8 @@ describe("Client", function () {
                 done();
             });
         });
-        it("should get the local and remote replicas for a given keyspace if isMetadataSyncEnabled is false but keyspace metadata is present", function (done) {
-            const client = newInstance({ isMetadataSyncEnabled: false });
+        it("should get the local and remote replicas for a given keyspace when keyspace metadata is present", function (done) {
+            const client = newInstance({});
             client.connect(function (err) {
                 assert.ifError(err);
                 client.metadata.refreshKeyspace(
@@ -67,18 +67,6 @@ describe("Client", function () {
                         done();
                     },
                 );
-            });
-        });
-        it("should return null if keyspace metadata is not present", function (done) {
-            const client = newInstance({ isMetadataSyncEnabled: false });
-            client.connect(function (err) {
-                assert.ifError(err);
-                const replicas = client.getReplicas(
-                    "sampleks1",
-                    utils.allocBufferFromArray([0, 0, 0, 1]),
-                );
-                assert.strictEqual(null, replicas);
-                done();
             });
         });
         it("should get the closest replica if no keyspace specified", function (done) {
@@ -169,7 +157,7 @@ describe("Client", function () {
                 );
             });
         });
-    }); 
+    });
     partitionerSuite("Murmur3Partitioner");
     partitionerSuite("RandomPartitioner");
     partitionerSuite("ByteOrderedPartitioner");

--- a/test/integration/broken/metadata-tests.js
+++ b/test/integration/broken/metadata-tests.js
@@ -26,9 +26,6 @@ describe("metadata @SERVER_API", function () {
         describe("#keyspaces", function () {
             it("should keep keyspace information up to date", function (done) {
                 const client = newInstance();
-                const nonSyncClient = newInstance({
-                    isMetadataSyncEnabled: false,
-                });
 
                 function checkKeyspaceWithInfo(
                     ks,
@@ -66,7 +63,6 @@ describe("metadata @SERVER_API", function () {
                 utils.series(
                     [
                         client.connect.bind(client),
-                        nonSyncClient.connect.bind(nonSyncClient),
                         function checkKeyspaces(next) {
                             const m = client.metadata;
                             assert.ok(m);
@@ -128,48 +124,7 @@ describe("metadata @SERVER_API", function () {
                                 "dc1",
                                 "1",
                             );
-
-                            // There should be no keyspace metadata for the non sync client until its fetched via refreshKeyspaces.
-                            const ks = nonSyncClient.metadata.keyspaces;
-                            assert.ok(ks["ks1"] === undefined);
-                            assert.ok(ks["ks2"] === undefined);
-                            assert.ok(ks["ks3"] === undefined);
-                            assert.ok(ks["ks4"] === undefined);
-
-                            nonSyncClient.metadata.refreshKeyspaces(
-                                function (err) {
-                                    assert.ifError(err);
-                                    checkKeyspace(
-                                        nonSyncClient,
-                                        "ks1",
-                                        "org.apache.cassandra.locator.SimpleStrategy",
-                                        "replication_factor",
-                                        "3",
-                                    );
-                                    checkKeyspace(
-                                        nonSyncClient,
-                                        "ks2",
-                                        "org.apache.cassandra.locator.SimpleStrategy",
-                                        "replication_factor",
-                                        "2",
-                                    );
-                                    checkKeyspace(
-                                        nonSyncClient,
-                                        "ks3",
-                                        "org.apache.cassandra.locator.SimpleStrategy",
-                                        "replication_factor",
-                                        "1",
-                                    );
-                                    checkKeyspace(
-                                        nonSyncClient,
-                                        "ks4",
-                                        "org.apache.cassandra.locator.NetworkTopologyStrategy",
-                                        "dc1",
-                                        "1",
-                                    );
-                                    next();
-                                },
-                            );
+                            next();
                         },
                         helper.toTask(
                             client.execute,
@@ -185,32 +140,9 @@ describe("metadata @SERVER_API", function () {
                                 "dc1",
                                 "1",
                             );
-
-                            // rf strategy should not have changed yet on nonSyncClient without refreshing explicitly.
-                            checkKeyspace(
-                                nonSyncClient,
-                                "ks3",
-                                "org.apache.cassandra.locator.SimpleStrategy",
-                                "replication_factor",
-                                "1",
-                            );
-
-                            nonSyncClient.metadata.refreshKeyspace(
-                                "ks3",
-                                function (err, ks) {
-                                    assert.ifError(err);
-                                    checkKeyspaceWithInfo(
-                                        ks,
-                                        "org.apache.cassandra.locator.NetworkTopologyStrategy",
-                                        "dc1",
-                                        "1",
-                                    );
-                                    next();
-                                },
-                            );
+                            next();
                         },
                         client.shutdown.bind(client),
-                        nonSyncClient.shutdown.bind(nonSyncClient),
                     ],
                     done,
                 );
@@ -703,9 +635,7 @@ describe("metadata @SERVER_API", function () {
         describe("#refreshKeyspace()", function () {
             describe("with no callback specified", function () {
                 it("should return keyspace in a promise", function () {
-                    const client = newInstance({
-                        isMetadataSyncEnabled: false,
-                    });
+                    const client = newInstance({});
                     return client
                         .connect()
                         .then(function () {
@@ -724,9 +654,7 @@ describe("metadata @SERVER_API", function () {
         describe("#refreshKeyspaces()", function () {
             describe("with no callback specified", function () {
                 it("should return keyspaces in a promise", function () {
-                    const client = newInstance({
-                        isMetadataSyncEnabled: false,
-                    });
+                    const client = newInstance({});
                     return client
                         .connect()
                         .then(function () {
@@ -1741,38 +1669,24 @@ describe("metadata @SERVER_API", function () {
             );
             it("should retrieve the updated metadata after a schema change", function (done) {
                 const client = newInstance();
-                const nonSyncClient = newInstance({
-                    isMetadataSyncEnabled: false,
-                });
-                const clients = [client, nonSyncClient];
                 utils.series(
                     [
                         client.connect.bind(client),
-                        nonSyncClient.connect.bind(nonSyncClient),
                         helper.toTask(
                             client.execute,
                             client,
                             "CREATE TABLE ks_tbl_meta.tbl_changing (id uuid PRIMARY KEY, text_sample text)",
                         ),
                         function checkTable1(next) {
-                            utils.each(
-                                clients,
-                                function (client, eachNext) {
-                                    client.metadata.getTable(
-                                        "ks_tbl_meta",
-                                        "tbl_changing",
-                                        function (err, table) {
-                                            assert.ifError(err);
-                                            assert.ok(table);
-                                            assert.strictEqual(
-                                                table.columns.length,
-                                                2,
-                                            );
-                                            eachNext();
-                                        },
-                                    );
+                            client.metadata.getTable(
+                                "ks_tbl_meta",
+                                "tbl_changing",
+                                function (err, table) {
+                                    assert.ifError(err);
+                                    assert.ok(table);
+                                    assert.strictEqual(table.columns.length, 2);
+                                    next();
                                 },
-                                next,
                             );
                         },
                         helper.toTask(
@@ -1781,36 +1695,24 @@ describe("metadata @SERVER_API", function () {
                             "ALTER TABLE ks_tbl_meta.tbl_changing ADD new_col1 timeuuid",
                         ),
                         function checkTable2(next) {
-                            utils.each(
-                                clients,
-                                function (clien, eachNext) {
-                                    client.metadata.getTable(
-                                        "ks_tbl_meta",
-                                        "tbl_changing",
-                                        function (err, table) {
-                                            assert.ifError(err);
-                                            assert.ok(table);
-                                            assert.strictEqual(
-                                                table.columns.length,
-                                                3,
-                                            );
-                                            assert.ok(
-                                                table.columnsByName["new_col1"],
-                                            );
-                                            assert.strictEqual(
-                                                table.columnsByName["new_col1"]
-                                                    .type.code,
-                                                types.dataTypes.timeuuid,
-                                            );
-                                            eachNext();
-                                        },
+                            client.metadata.getTable(
+                                "ks_tbl_meta",
+                                "tbl_changing",
+                                function (err, table) {
+                                    assert.ifError(err);
+                                    assert.ok(table);
+                                    assert.strictEqual(table.columns.length, 3);
+                                    assert.ok(table.columnsByName["new_col1"]);
+                                    assert.strictEqual(
+                                        table.columnsByName["new_col1"].type
+                                            .code,
+                                        types.dataTypes.timeuuid,
                                     );
+                                    next();
                                 },
-                                next,
                             );
                         },
-                        client.shutdown.bind(nonSyncClient),
-                        nonSyncClient.shutdown.bind(nonSyncClient),
+                        client.shutdown.bind(client),
                     ],
                     done,
                 );
@@ -1976,15 +1878,9 @@ describe("metadata @SERVER_API", function () {
                     keyspace: "ks_view_meta",
                     refreshSchemaDelay: 50,
                 });
-                const nonSyncClient = newInstance({
-                    keyspace: "ks_view_meta",
-                    isMetadataSyncEnabled: false,
-                });
-                const clients = [client, nonSyncClient];
                 utils.series(
                     [
                         client.connect.bind(client),
-                        nonSyncClient.connect.bind(nonSyncClient),
                         helper.toTask(
                             client.execute,
                             client,
@@ -1996,40 +1892,34 @@ describe("metadata @SERVER_API", function () {
                                 " 'SizeTieredCompactionStrategy' }",
                         ),
                         function checkView1(next) {
-                            utils.each(
-                                clients,
-                                function (client, eachNext) {
-                                    client.metadata.getMaterializedView(
-                                        "ks_view_meta",
-                                        "monthlyhigh",
-                                        function (err, view) {
-                                            assert.ifError(err);
-                                            assert.ok(view);
-                                            assert.strictEqual(
-                                                view.partitionKeys.length,
-                                                3,
-                                            );
-                                            assert.strictEqual(
-                                                view.partitionKeys
-                                                    .map((x) => x.name)
-                                                    .join(", "),
-                                                "game, year, month",
-                                            );
-                                            assert.strictEqual(
-                                                view.clusteringKeys
-                                                    .map((x) => x.name)
-                                                    .join(", "),
-                                                "score, user, day",
-                                            );
-                                            helper.assertContains(
-                                                view.compactionClass,
-                                                "SizeTieredCompactionStrategy",
-                                            );
-                                            eachNext();
-                                        },
+                            client.metadata.getMaterializedView(
+                                "ks_view_meta",
+                                "monthlyhigh",
+                                function (err, view) {
+                                    assert.ifError(err);
+                                    assert.ok(view);
+                                    assert.strictEqual(
+                                        view.partitionKeys.length,
+                                        3,
                                     );
+                                    assert.strictEqual(
+                                        view.partitionKeys
+                                            .map((x) => x.name)
+                                            .join(", "),
+                                        "game, year, month",
+                                    );
+                                    assert.strictEqual(
+                                        view.clusteringKeys
+                                            .map((x) => x.name)
+                                            .join(", "),
+                                        "score, user, day",
+                                    );
+                                    helper.assertContains(
+                                        view.compactionClass,
+                                        "SizeTieredCompactionStrategy",
+                                    );
+                                    next();
                                 },
-                                next,
                             );
                         },
                         helper.toTask(
@@ -2038,33 +1928,27 @@ describe("metadata @SERVER_API", function () {
                             "ALTER MATERIALIZED VIEW monthlyhigh" +
                                 " WITH compaction = { 'class' : 'LeveledCompactionStrategy' }",
                         ),
-                        function checkView1(next) {
-                            utils.each(
-                                clients,
-                                function (client, eachNext) {
-                                    client.metadata.getMaterializedView(
-                                        "ks_view_meta",
-                                        "monthlyhigh",
-                                        function (err, view) {
-                                            assert.ifError(err);
-                                            assert.ok(view);
-                                            assert.strictEqual(
-                                                view.partitionKeys.length,
-                                                3,
-                                            );
-                                            assert.strictEqual(
-                                                view.clusteringKeys.length,
-                                                3,
-                                            );
-                                            helper.assertContains(
-                                                view.compactionClass,
-                                                "LeveledCompactionStrategy",
-                                            );
-                                            eachNext();
-                                        },
+                        function checkView2(next) {
+                            client.metadata.getMaterializedView(
+                                "ks_view_meta",
+                                "monthlyhigh",
+                                function (err, view) {
+                                    assert.ifError(err);
+                                    assert.ok(view);
+                                    assert.strictEqual(
+                                        view.partitionKeys.length,
+                                        3,
                                     );
+                                    assert.strictEqual(
+                                        view.clusteringKeys.length,
+                                        3,
+                                    );
+                                    helper.assertContains(
+                                        view.compactionClass,
+                                        "LeveledCompactionStrategy",
+                                    );
+                                    next();
                                 },
-                                next,
                             );
                         },
                         helper.toTask(
@@ -2073,24 +1957,17 @@ describe("metadata @SERVER_API", function () {
                             "DROP MATERIALIZED VIEW monthlyhigh",
                         ),
                         function checkDropped(next) {
-                            utils.each(
-                                clients,
-                                function (client, eachNext) {
-                                    client.metadata.getMaterializedView(
-                                        "ks_view_meta",
-                                        "monthlyhigh",
-                                        function (err, view) {
-                                            assert.ifError(err);
-                                            assert.strictEqual(view, null);
-                                            eachNext();
-                                        },
-                                    );
+                            client.metadata.getMaterializedView(
+                                "ks_view_meta",
+                                "monthlyhigh",
+                                function (err, view) {
+                                    assert.ifError(err);
+                                    assert.strictEqual(view, null);
+                                    next();
                                 },
-                                next,
                             );
                         },
                         client.shutdown.bind(client),
-                        nonSyncClient.shutdown.bind(nonSyncClient),
                     ],
                     done,
                 );

--- a/test/integration/broken/udf-tests.js
+++ b/test/integration/broken/udf-tests.js
@@ -292,7 +292,6 @@ vdescribe("2.2", "Metadata @SERVER_API", function () {
             const client = newInstance({ keyspace: keyspace });
             const nonSyncClient = newInstance({
                 keyspace: keyspace,
-                isMetadataSyncEnabled: false,
             });
             const clients = [client, nonSyncClient];
             utils.series(
@@ -615,7 +614,6 @@ vdescribe("2.2", "Metadata @SERVER_API", function () {
             const client = newInstance({ keyspace: keyspace });
             const nonSyncClient = newInstance({
                 keyspace: keyspace,
-                isMetadataSyncEnabled: false,
             });
             const clients = [client, nonSyncClient];
             utils.series(

--- a/test/typescript/metadata-tests.ts
+++ b/test/typescript/metadata-tests.ts
@@ -1,6 +1,7 @@
 import { Client, Host, metadata, types } from "../../main";
 import TableMetadata = metadata.TableMetadata;
 import QueryTrace = metadata.QueryTrace;
+import KeyspaceMetadata = metadata.KeyspaceMetadata;
 
 /*
  * TypeScript definitions compilation tests for metadata module.
@@ -13,34 +14,32 @@ async function myTest(): Promise<any> {
     });
 
     let promise: Promise<void>;
-    let s: string;
     let n: number;
     let hosts: Host[];
-    let emptyCb = (err: Error) => {};
 
     promise = client.connect();
 
     hosts = client.metadata.getReplicas("ks1", Buffer.from([0]));
 
-    let table: TableMetadata = await client.metadata.getTable("ks1", "table1");
-    client.metadata.getTable("ks1", "table1", (err, t) =>
-        useResult<TableMetadata>(err, t),
+    const table: TableMetadata | null = client.metadata.getTable(
+        "ks1",
+        "table1",
     );
 
-    client.metadata.refreshKeyspace("ks", emptyCb);
-    promise = client.metadata.refreshKeyspace("ks");
-    s = client.metadata.keyspaces["ks1"].strategy;
+    const keyspaces: Map<string, KeyspaceMetadata> =
+        client.metadata.getKeyspaces();
+    const keyspace: KeyspaceMetadata | null =
+        client.metadata.getKeyspace("ks1");
 
-    let trace: QueryTrace = await client.metadata.getTrace(types.Uuid.random());
-    client.metadata.getTrace(types.Uuid.random(), (err, t) =>
-        useResult<QueryTrace>(err, t),
+    const trace: QueryTrace | null = client.metadata.getTrace(
+        types.Uuid.random(),
+    );
+    const traceWithConsistency: QueryTrace | null = client.metadata.getTrace(
+        types.Uuid.random(),
+        types.consistencies.one,
     );
 
     hosts = client.getState().getConnectedHosts();
     n = client.getState().getInFlightQueries(hosts[0]);
     n = client.getState().getOpenConnections(hosts[0]);
-}
-
-function useResult<T>(err: Error, rs: T): void {
-    // Mock function that takes the parameters defined in the driver callback
 }

--- a/test/unit-broken/metadata-tests.js
+++ b/test/unit-broken/metadata-tests.js
@@ -1568,7 +1568,6 @@ describe("Metadata", function () {
             ];
 
             const options = utils.extend({}, clientOptions.defaultOptions());
-            options.isMetadataSyncEnabled = false;
             const cc = getControlConnectionForTable(tableRow, columnRows);
             const metadata = new Metadata(options, cc);
             metadata.initialized = true;


### PR DESCRIPTION
- Removed the no longer applicable `clearPrepared` endpoint.
- Exposed `checkSchemaAgreement` as public API
- Made Metadata class methods declarations sync (as introduced in #418), and rewrote `test/typescript/metadata-tests.ts` to match it.
- Renamed the keyspace API from misleading `refreshKeyspace(s)` to `getKeyspace(s)`.
- Removed `isMetadataSyncEnabled` option
- Fixed formatting and ordering.