### PR TITLE
Update CCM version and migrate from SimpleStrategy to NetworkTopologyStrategy

### DIFF
--- a/test/integration/broken/client-metadata-tests-long.js
+++ b/test/integration/broken/client-metadata-tests-long.js
@@ -188,7 +188,7 @@ describe("Client", function () {
                     client
                         .execute(
                             "CREATE KEYSPACE ks_rs_is_schema_in_agreement" +
-                                " WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 1}",
+                                " WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor' : 1}",
                         )
                         .then((rs) =>
                             assert.strictEqual(
@@ -204,7 +204,7 @@ describe("Client", function () {
                 it("should return false after executing DDL queries", (done) => {
                     const createQuery =
                         "CREATE KEYSPACE ks_meta_check_agreement" +
-                        " WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 1}";
+                        " WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor' : 1}";
 
                     utils.series(
                         [

--- a/test/integration/broken/udf-tests.js
+++ b/test/integration/broken/udf-tests.js
@@ -19,7 +19,7 @@ vdescribe("2.2", "Metadata @SERVER_API", function () {
     before(function createSchema(done) {
         const client = newInstance();
         const queries = [
-            "CREATE KEYSPACE  ks_udf WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 3}",
+            "CREATE KEYSPACE  ks_udf WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor' : 3}",
             "CREATE FUNCTION  ks_udf.return_one() RETURNS NULL ON NULL INPUT RETURNS int LANGUAGE java AS 'return 1;'",
             "CREATE FUNCTION  ks_udf.plus(s int, v int) RETURNS NULL ON NULL INPUT RETURNS int LANGUAGE java AS 'return s+v;'",
             "CREATE FUNCTION  ks_udf.plus(s bigint, v bigint) RETURNS NULL ON NULL INPUT RETURNS bigint LANGUAGE java AS 'return s+v;'",

--- a/test/integration/supported/client-auth-tests.js
+++ b/test/integration/supported/client-auth-tests.js
@@ -13,7 +13,12 @@ describe("Client", function () {
         helper.setup(1, {
             initClient: false,
             ccmOptions: {
-                yaml: ["authenticator:PasswordAuthenticator"],
+                yaml: [
+                    "authenticator:PasswordAuthenticator",
+                    "authorizer:CassandraAuthorizer",
+                    "auth_superuser_name:cassandra",
+                    "auth_superuser_salted_password:$6$x7IFjiX5VCpvNiFk$2IfjTvSyGL7zerpV.wbY7mJjaRCrJ/68dtT3UpT.sSmNYz1bPjtn3mH.kJKFvaZ2T4SbVeBijjmwGjcb83LlV/",
+                ],
                 jvmArgs: ["-Dcassandra.superuser_setup_delay_ms=0"],
             },
         });

--- a/test/integration/supported/client-execute-prepared-tests.js
+++ b/test/integration/supported/client-execute-prepared-tests.js
@@ -2279,7 +2279,11 @@ describe("Client @SERVER_API", function () {
             const keyspace = "ks_view_prepared";
             before(function createTables(done) {
                 const queries = [
-                    "CREATE KEYSPACE ks_view_prepared WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 1}",
+                    // This test has hardcoded assumptions about which node will coordinate a request based on token-aware routing, so tablets must stay disabled.
+                    helper.keyspaceDefinitionWithTabletsDisabled(
+                        setupInfo.client,
+                        "CREATE KEYSPACE ks_view_prepared WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor' : 1}",
+                    ),
                     "CREATE TABLE ks_view_prepared.scores (user TEXT, game TEXT, year INT, month INT, day INT, score INT, PRIMARY KEY (user, game, year, month, day))",
                     "CREATE MATERIALIZED VIEW ks_view_prepared.alltimehigh AS SELECT * FROM scores WHERE game IS NOT NULL AND year IS NOT NULL AND month IS NOT NULL AND day IS NOT NULL AND score IS NOT NULL AND user IS NOT NULL PRIMARY KEY (game, score, year, month, day, user) WITH CLUSTERING ORDER BY (score DESC, year DESC, month DESC, day DESC, user DESC)",
                 ];

--- a/test/integration/supported/client-pool-tests.js
+++ b/test/integration/supported/client-pool-tests.js
@@ -676,11 +676,11 @@ describe("Client", function () {
 
         it("should wait for schema agreement before calling back", function (done) {
             const queries = [
-                "CREATE KEYSPACE ks1 WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 3};",
+                "CREATE KEYSPACE ks1 WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor' : 3};",
                 "CREATE TABLE ks1.tbl1 (id uuid PRIMARY KEY, value text)",
                 "SELECT * FROM ks1.tbl1",
                 "SELECT * FROM ks1.tbl1 where id = d54cb06d-d168-45a0-b1b2-9f5c75435d3d",
-                "CREATE KEYSPACE ks2 WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 3};",
+                "CREATE KEYSPACE ks2 WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor' : 3};",
                 "CREATE TABLE ks2.tbl2 (id uuid PRIMARY KEY, value text)",
                 "SELECT * FROM ks2.tbl2",
                 "SELECT * FROM ks2.tbl2",

--- a/test/integration/supported/load-balancing-tests.js
+++ b/test/integration/supported/load-balancing-tests.js
@@ -90,7 +90,6 @@ context("with a reusable 3 node cluster", function () {
     before(function (done) {
         utils.eachSeries(
             [
-                "CREATE KEYSPACE ks_simple_rp1 WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 1}",
                 // In the tests, we have some hardcoded assumptions, which nodes will be contacted (by usage of token aware policy).
                 // Those nodes are determined based on how Vnodes work - meaning that when testing on scylla, we need to disable tablets,
                 // which otherwise break the assumptions about which nodes to expect as part of the request coordinator.
@@ -102,12 +101,11 @@ context("with a reusable 3 node cluster", function () {
                     client,
                     "CREATE KEYSPACE ks_network_rp2 WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1' : 2}",
                 ),
-                "CREATE TABLE ks_simple_rp1.table_a (id int primary key, name int)",
                 "CREATE TABLE ks_network_rp1.table_b (id int primary key, name int)",
                 "CREATE TABLE ks_network_rp2.table_c (id int primary key, name int)",
                 "CREATE TABLE ks_network_rp2.table_composite (id1 text, id2 text, primary key ((id1, id2)))",
                 // Try to prevent consistency issues in the query trace
-                "ALTER KEYSPACE system_traces WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'}",
+                "ALTER KEYSPACE system_traces WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': '1'}",
             ],
             function (q, next) {
                 client.execute(q, next);
@@ -149,9 +147,6 @@ context("with a reusable 3 node cluster", function () {
         it("should target the correct replica for partition with logged keyspace", function (done) {
             utils.series(
                 [
-                    function testCaseWithSimpleStrategy(next) {
-                        testNoHops("ks_simple_rp1", "table_a", 1, next);
-                    },
                     function testCaseWithNetworkStrategy(next) {
                         testNoHops("ks_network_rp1", "table_b", 1, next);
                     },
@@ -163,7 +158,7 @@ context("with a reusable 3 node cluster", function () {
             );
         });
         it("should target the correct partition on a different keyspace", function (done) {
-            testNoHops("ks_simple_rp1", "ks_network_rp2.table_c", 2, done);
+            testNoHops("ks_network_rp1", "ks_network_rp2.table_c", 2, done);
         });
         it("should target correct replica for composite routing key", function (done) {
             const client = new Client({
@@ -223,7 +218,7 @@ context("with a reusable 3 node cluster", function () {
         });
         it("should balance between replicas on a different keyspace", function (done) {
             testAllReplicasAreUsedAsCoordinator(
-                "ks_simple_rp1",
+                "ks_network_rp1",
                 "ks_network_rp2.table_c",
                 2,
                 done,
@@ -345,7 +340,7 @@ context("with a reusable 3 node cluster", function () {
                 done,
             );
         });
-       
+
         it("should throw TypeError if invalid routingKey type is provided", function (done) {
             const client = new Client({
                 policies: {

--- a/test/test-helper.js
+++ b/test/test-helper.js
@@ -768,8 +768,8 @@ const helper = {
     createKeyspaceCql: function (keyspace, replicationFactor, durableWrites) {
         return util.format(
             "CREATE KEYSPACE %s" +
-                " WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : %d}" +
-                " AND durable_writes = %s;",
+                " WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor' : %d}" +
+                " AND durable_writes = %s",
             keyspace,
             replicationFactor || 1,
             !!durableWrites,
@@ -1005,7 +1005,7 @@ const helper = {
             isScylla: isScylla,
             version:
                 process.env["CCM_VERSION"] ||
-                (isScylla ? "release:2025.3" : "3.11.4"),
+                (isScylla ? "release:2026.2.2" : "3.11.4"),
         };
     },
 


### PR DESCRIPTION
Upgrade the CCM version used for integration tests to 2026.2.2. This change breaks some tests, so to make sure everything passes, we introduced two updates:
- update config options in client-auth-tests to allow for plain-text authentication.
- migrate all usage of SimpleStrategy to NetworkStrategy, keeping only those present in metadata tests (SimpleStrategy is deprecated, and soon ScyllaDB will drop support for it). 

Fixes: #179 

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~[ ] I added relevant tests for new features and bug fixes.~
- [x] All commits compile, pass static checks and pass tests.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~[ ] I have provided docstrings for the public items that I want to introduce.~
- ~[ ] I have made sure that the type stubs / TS definitions match the JS public API.~
- ~[ ] I have adjusted the documentation in `./docs/source/`.~
- ~[ ] I have adjusted the migration documentation (removed/changed API) in `./docs/source/migration-guide`.~
- [x] I added appropriate `Fixes:` annotations to PR description.
