### PR TITLE
Client Routes support

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -26,7 +26,7 @@ jobs:
         settings:
           - host: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-            build: npm run build -- --target x86_64-unknown-linux-gnu
+            build: npm run build:test -- --target x86_64-unknown-linux-gnu
     name: Build and run integration tests - ${{ matrix.settings.target }} - node@20
     runs-on: ${{ matrix.settings.host }}
     timeout-minutes: 60

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,12 @@ openssl = "0.10.70"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["registry"] }
 
+scylla-proxy = { version = "0.0.6", optional = true }
+
+[features]
+# Enables the client-routes fake-NLB test helpers in src/tests/client_routes_proxy_tests.rs.
+client-routes-proxy-tests = ["scylla-proxy"]
+
 [lints.rust]
 unsafe-op-in-unsafe-fn = "warn"
 
@@ -33,4 +39,3 @@ panic = "abort"
 
 [profile.dev]
 panic = "abort"
-

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 
 napi = { version = "3.6.0", default-features = false, features = ["napi4", "napi6", "async"] }
 napi-derive = "3.4.0"
-scylla = { version = "1.7.0", features = ["num-bigint-03", "openssl-010", "unstable-nodejs-rs"] }
+scylla = { version = "1.7.0", features = ["num-bigint-03", "openssl-010", "unstable-nodejs-rs", "unstable-client-routes"] }
 tokio = { version = "1.34", features = ["full"] }
 futures = "0.3"
 uuid = "1"

--- a/docs/source/connecting/client-routes.md
+++ b/docs/source/connecting/client-routes.md
@@ -1,0 +1,83 @@
+# Client Routes (Private Networking)
+
+When connecting to ScyllaDB Cloud clusters over private networking (e.g. AWS PrivateLink or
+GCP Private Service Connect), nodes are not reachable at the addresses they broadcast to each
+other. Each node is instead reachable through a proxy whose address is stored in the
+`system.client_routes` table. The driver has to be told to route through that table — that is
+what the **Client Routes** feature does.
+
+## How it works
+
+1. Each proxy is identified by a **connection id** — a string the cloud infrastructure
+   assigns to a particular PrivateLink / Private Service Connect connection.
+2. On session startup, and on every metadata refresh, the driver reads `system.client_routes`
+   to find which address and port to use for each node, filtered by the configured connection ids.
+3. The driver subscribes to `CLIENT_ROUTES_CHANGE` events, so it can pick up changes to the table
+   without waiting for a full metadata refresh.
+
+## Usage
+
+Provide a `clientRoutes` option alongside `contactPoints`:
+
+```javascript
+const { Client } = require('@scylladb/driver');
+
+(async () => {
+  const client = new Client({
+    contactPoints: ['my-privatelink-endpoint.amazonaws.com:9042'],
+    localDataCenter: 'datacenter1',
+    clientRoutes: {
+      proxies: [
+        { connectionId: 'my-connection-id' },
+      ],
+    },
+  });
+
+  await client.connect();
+})();
+```
+
+`contactPoints` is still required — use the address your cloud setup gives you for the
+initial connection. Contact points are never translated, which is what makes the first connection
+possible before any route is known.
+
+## Proxies
+
+`clientRoutes.proxies` is a non-empty array; each entry identifies one ScyllaDB Cloud connection
+to read routes for:
+
+| Option             | Description                                                                                                                                                  |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `connectionId`     | The ScyllaDB Cloud connection id. Used to filter the rows of `system.client_routes` that apply to this proxy. This is required.                          |
+| `hostnameOverride` | Overrides the hostname that would otherwise be read from `system.client_routes` for this connection id. Useful for e.g. local testing.  |
+
+More than one proxy can be specified when connecting, for example one per availability zone -
+pass all of them in `clientRoutes.proxies`.
+
+```javascript
+clientRoutes: {
+  proxies: [
+    { connectionId: 'conn-id-az-1' },
+    { connectionId: 'conn-id-az-2' },
+  ],
+},
+```
+
+## Restrictions
+
+`clientRoutes` is mutually exclusive with:
+
+- **`policies.addressResolution`** — client routes performs its own Host ID based address
+  translation, so a custom address translator would conflict with it.
+- **`sslOptions`** — TLS is not yet supported for client routes connections.
+
+Combining either with `clientRoutes` throws when the client is created.
+
+## Limitations
+
+- **Mixed clusters are not supported.** Every node must be reachable through client routes, and so
+  must have a corresponding entry in `system.client_routes`. A cluster where some nodes are behind
+  private networking and others are reachable directly will not work.
+- _Advanced_ shard awareness (the driver picking a source port to target a specific shard) is
+  disabled, because the proxy infrastructure does not preserve it. _Basic_ shard awareness still
+  works, so requests are still routed to the correct shard.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -20,6 +20,7 @@ Support for some optional driver features is planned for upcoming releases.
    logging/logging
    policies/index
    connecting/authentication
+   connecting/client-routes
    shutdown/shutdown
    migration-guide/migration-guide
    api/index
@@ -37,6 +38,7 @@ Contents
 - :doc:`Fetching Large Result Sets <paging/paging>` - Paging through large result sets
 - :doc:`Policies <policies/index>` - Load balancing and retry policies
 - :doc:`Authentication <connecting/authentication>` - Connecting with credentials or SSL
+- :doc:`Client Routes <connecting/client-routes>` - Connecting over private networking
 - :doc:`Shutdown <shutdown/shutdown>` - How the driver manages connection lifecycle
 - :doc:`Migration Guide <migration-guide/migration-guide>` - Migrating from the Apache ``cassandra-driver``
 - :doc:`API Reference <api/index>` - Full API documentation
@@ -59,6 +61,7 @@ The driver supports the following:
 - SSL support
 - Configurable load balancing, retry policies
 - Simple address translation policy
+- Private networking
 - Error handling, based on the Rust driver
 - Driver logging
 - Faster performance, compared to DataStax Node.js driver(*)

--- a/lib/client-options.js
+++ b/lib/client-options.js
@@ -40,6 +40,16 @@ const { ExecutionProfile } = require("./execution-profile.js");
  * but it is usually a good idea to provide more than one contact point, because if that single contact point is
  * unavailable, the driver will not be able to initialize correctly.
  *
+ * @property {Object} [clientRoutes] Client routes configuration, for connecting through proxied setups
+ * such as AWS PrivateLink or GCP Private Service Connect.
+ *
+ * Mutually exclusive with `policies.addressResolution` and, for now, with `sslOptions`.
+ *
+ * @property {Array.<Object>} clientRoutes.proxies The proxies to read routes for. At least one is required.
+ * @property {String} clientRoutes.proxies[].connectionId The ScyllaDB Cloud connection id, used to filter the
+ * rows of `system.client_routes` that apply to this proxy.
+ * @property {String} [clientRoutes.proxies[].hostnameOverride] Overrides the hostname read from
+ * `system.client_routes` for this connection id. Useful for testing and for some cloud architectures.
  * @property {String} [localDataCenter] The local data center to use.
  *
  * If using DCAwareRoundRobinPolicy (default), this option is required and only hosts from this data center are
@@ -988,6 +998,12 @@ function setRustOptions(options) {
                     );
             }
         }
+    }
+
+    if (options.clientRoutes) {
+        rustOptions.clientRoutesConfig = {
+            proxies: options.clientRoutes.proxies,
+        };
     }
 
     if (options.sslOptions) {

--- a/main.d.ts
+++ b/main.d.ts
@@ -227,8 +227,20 @@ export interface ExecutionOptions {
   setHints(hints: string[]): void;
 }
 
+/** A single client routes proxy the driver should read `system.client_routes` for. */
+export interface ClientRoutesProxy {
+  /** The ScyllaDB Cloud connection id used to filter `system.client_routes`. */
+  connectionId: string;
+  /**
+   * Overrides the hostname read from `system.client_routes` for this connection id.
+   * Useful for testing and for some cloud architectures.
+   */
+  hostnameOverride?: string;
+}
+
 export interface ClientOptions {
   contactPoints?: string[];
+  clientRoutes?: { proxies: ClientRoutesProxy[] };
   localDataCenter?: string;
   keyspace?: string;
   authProvider?: auth.AuthProvider;

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
   "scripts": {
     "build:ts": "tsc -p tsconfig.build.json",
     "build": "sh -c 'napi build --platform --release \"$@\" && npm run build:ts' --",
+    "build:test": "sh -c 'napi build --platform --features client-routes-proxy-tests \"$@\" && npm run build:ts' --",
     "all-tests": "npm run unit && npm run integration && npm run unit-not-supported",
     "unit": "./node_modules/.bin/mocha test/unit -t 5000 --recursive",
     "unit-gc": "./node_modules/.bin/mocha --node-option=expose-gc test/unit -t 5000 --recursive --grep 'expose-gc'",

--- a/src/custom-types.d.ts
+++ b/src/custom-types.d.ts
@@ -29,7 +29,7 @@ export type PagingResult = [PagingStateWrapper | null, QueryResultWrapper]
  * Result of a paged query that can be continued via a QueryExecutor.
  * Serialized as a 3-element tuple: [pagingState, result, executor].
  * - pagingState is null when there are no more pages.
- * 
+ *
  * This type can also be used to represent an unpaged query result, to allow for better code reuse.
  * This kind of result can be represented by setting pagingState and executor to undefined.
  */
@@ -80,6 +80,17 @@ export interface LoadBalancingConfig {
   allowList?: Array<string>
 }
 
+/** A single client routes proxy passed to ClientRoutesConfig.proxies. */
+export interface ClientRoutesProxyConfig {
+  connectionId?: string
+  hostnameOverride?: string
+}
+
+/** Client routes configuration passed to SessionOptions.clientRoutesConfig. */
+export interface ClientRoutesConfig {
+  proxies?: Array<ClientRoutesProxyConfig>
+}
+
 /** Options for creating a new session via SessionWrapper.createSession. */
 export interface SessionOptions {
   connectPoints?: Array<string>
@@ -93,6 +104,7 @@ export interface SessionOptions {
   sslOptions?: SslOptions
   loadBalancingConfig?: LoadBalancingConfig
   retryPolicy?: RetryPolicyKind
+  clientRoutesConfig?: ClientRoutesConfig
 }
 
 /** Per-query options passed to QueryOptionsWrapper. */

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -12,9 +12,14 @@ use openssl::ssl::{
 use openssl::x509::X509;
 use openssl::x509::store::X509StoreBuilder;
 use scylla::client::SelfIdentity;
+use scylla::client::client_routes::{
+    ClientRoutesConfig as ScyllaClientRoutesConfig, ClientRoutesProxy,
+};
 use scylla::client::execution_profile::ExecutionProfileBuilder;
+use scylla::client::session::Session;
 use scylla::client::session_builder::{
-    GenericSessionBuilder, SessionBuilder, SessionBuilderKindSupportsKnownNodes,
+    ClientRoutesSessionBuilder, GenericSessionBuilder, SessionBuilder,
+    SessionBuilderKindSupportsKnownNodes,
 };
 use scylla::policies::host_filter::AllowListHostFilter;
 use scylla::policies::load_balancing::{self, LoadBalancingPolicy};
@@ -64,7 +69,7 @@ pub struct LoadBalancingConfig {
     permit_dc_failover, permitDcFailover: bool,
     enable_shuffling_replicas, enableShufflingReplicas: bool,
     allow_list, allowList: Vec<String>,
-    
+
 });
 
 #[derive(Debug, PartialEq, Eq)]
@@ -82,6 +87,22 @@ pub struct FixedAddressTranslatorConfig {
     address_mapping, addressMapping: Vec<(SocketAddrWrapper, SocketAddrWrapper)>,
 });
 
+// A single client routes proxy: a Scylla Cloud connection id, and optionally a
+// hostname to use instead of the one read from system.client_routes for it -
+// useful for testing and for some cloud architectures.
+define_js_to_rust_convertible_object!(
+pub struct ClientRoutesProxyConfig {
+    connection_id, connectionId: String,
+    hostname_override, hostnameOverride: String,
+});
+
+// Configuration for client routes, where each node is reached through its own
+// port on a proxy rather than directly.
+define_js_to_rust_convertible_object!(
+pub struct ClientRoutesConfig {
+    proxies, proxies: Vec<ClientRoutesProxyConfig>,
+});
+
 define_js_to_rust_convertible_object!(
 pub struct SessionOptions {
     connect_points, connectPoints: Vec<String>,
@@ -96,6 +117,7 @@ pub struct SessionOptions {
     load_balancing_config, loadBalancingConfig: LoadBalancingConfig,
     retry_policy, retryPolicy: RetryPolicyKind,
     address_translator_config, addressTranslatorConfig: FixedAddressTranslatorConfig,
+    client_routes_config, clientRoutesConfig: ClientRoutesConfig,
 });
 
 impl Debug for SslOptions {
@@ -270,10 +292,29 @@ fn configure_ssl(options: &SslOptions) -> ConvertedResult<Option<SslContext>> {
     Ok(Some(ssl_context_builder.build()))
 }
 
-/// Applies every option that is meaningful for any kind of session builder.
+/// A session builder, in one of the two modes the driver supports.
 ///
-/// The rust driver exposes some options only on specific builder kinds, so those
-/// are applied by the caller instead.
+/// The rust driver models client routes as a separate builder typestate, which
+/// deliberately does not expose the options that would conflict with it (address
+/// translation and TLS), so the two builders cannot be unified into one value.
+pub(crate) enum ConfiguredSessionBuilder {
+    Default(SessionBuilder),
+    ClientRoutes(ClientRoutesSessionBuilder),
+}
+
+impl ConfiguredSessionBuilder {
+    // Returns a ConvertedResult rather than propagating NewSessionError, which is
+    // large enough to trip clippy::result_large_err.
+    pub(crate) async fn build(&self) -> ConvertedResult<Session> {
+        match self {
+            ConfiguredSessionBuilder::Default(builder) => Ok(builder.build().await?),
+            ConfiguredSessionBuilder::ClientRoutes(builder) => Ok(builder.build().await?),
+        }
+    }
+}
+
+/// Applies every option that is meaningful in both modes. TLS (for now)
+/// and address translation are default mode only.
 fn apply_common_options<K: SessionBuilderKindSupportsKnownNodes>(
     mut builder: GenericSessionBuilder<K>,
     options: &SessionOptions,
@@ -327,8 +368,21 @@ fn apply_common_options<K: SessionBuilderKindSupportsKnownNodes>(
 }
 
 pub(crate) fn configure_session_builder(
-    options: SessionOptions,
-) -> ConvertedResult<SessionBuilder> {
+    mut options: SessionOptions,
+) -> ConvertedResult<ConfiguredSessionBuilder> {
+    // Taken out so that the remaining fields can still be moved out by the callees.
+    match options.client_routes_config.take() {
+        None => Ok(ConfiguredSessionBuilder::Default(
+            configure_default_builder(options)?,
+        )),
+        Some(client_routes_config) => Ok(ConfiguredSessionBuilder::ClientRoutes(
+            configure_client_routes_builder(client_routes_config, &options)?,
+        )),
+    }
+}
+
+/// Configures a builder for a session that connects to nodes directly.
+fn configure_default_builder(options: SessionOptions) -> ConvertedResult<SessionBuilder> {
     let mut builder = apply_common_options(SessionBuilder::new(), &options)?;
 
     if let Some(ssl_options) = &options.ssl_options {
@@ -347,6 +401,66 @@ pub(crate) fn configure_session_builder(
     }
 
     Ok(builder)
+}
+
+/// Configures a builder for a session that reaches nodes through client routes
+/// proxies, resolving their addresses by Host ID.
+fn configure_client_routes_builder(
+    client_routes_config: ClientRoutesConfig,
+    options: &SessionOptions,
+) -> ConvertedResult<ClientRoutesSessionBuilder> {
+    // Both of these are already impossible to express on the client routes
+    // builder, but we reject them explicitly rather than silently ignore them.
+    if options.address_translator_config.is_some() {
+        return Err(ConvertedError::from(make_js_error(
+            "clientRoutes cannot be combined with an address resolution policy: \
+             client routes performs its own Host ID based address translation",
+        )));
+    }
+    if options.ssl_options.is_some() {
+        return Err(ConvertedError::from(make_js_error(
+            "clientRoutes cannot be combined with sslOptions: \
+             TLS is not yet supported for client routes connections",
+        )));
+    }
+
+    let config = convert_client_routes_config(client_routes_config)?;
+    apply_common_options(ClientRoutesSessionBuilder::new(config), options)
+}
+
+/// Converts the JS side client routes configuration into the rust driver's one.
+fn convert_client_routes_config(
+    client_routes_config: ClientRoutesConfig,
+) -> ConvertedResult<ScyllaClientRoutesConfig> {
+    let proxies = client_routes_config
+        .proxies
+        .unwrap_or_default()
+        .into_iter()
+        .enumerate()
+        .map(|(index, proxy_config)| {
+            let connection_id = proxy_config
+                .connection_id
+                .filter(|id| !id.is_empty())
+                .ok_or_else(|| {
+                    ConvertedError::from(make_js_error(format!(
+                        "clientRoutes proxy at index {index} must have a non-empty connectionId"
+                    )))
+                })?;
+
+            let mut proxy = ClientRoutesProxy::new_with_connection_id(connection_id);
+            if let Some(hostname) = proxy_config.hostname_override.filter(|h| !h.is_empty()) {
+                proxy = proxy.with_overridden_hostname(hostname);
+            }
+            Ok(proxy)
+        })
+        .collect::<ConvertedResult<Vec<_>>>()?;
+
+    // Rejects an empty proxy list.
+    ScyllaClientRoutesConfig::new(proxies).map_err(|err| {
+        ConvertedError::from(make_js_error(format!(
+            "Invalid clientRoutes configuration: {err}"
+        )))
+    })
 }
 
 fn create_load_balancing_policy(

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -13,7 +13,9 @@ use openssl::x509::X509;
 use openssl::x509::store::X509StoreBuilder;
 use scylla::client::SelfIdentity;
 use scylla::client::execution_profile::ExecutionProfileBuilder;
-use scylla::client::session_builder::SessionBuilder;
+use scylla::client::session_builder::{
+    GenericSessionBuilder, SessionBuilder, SessionBuilderKindSupportsKnownNodes,
+};
 use scylla::policies::host_filter::AllowListHostFilter;
 use scylla::policies::load_balancing::{self, LoadBalancingPolicy};
 use scylla::policies::retry::{DefaultRetryPolicy, FallthroughRetryPolicy, RetryPolicy};
@@ -268,11 +270,15 @@ fn configure_ssl(options: &SslOptions) -> ConvertedResult<Option<SslContext>> {
     Ok(Some(ssl_context_builder.build()))
 }
 
-pub(crate) fn configure_session_builder(
-    options: SessionOptions,
-) -> ConvertedResult<SessionBuilder> {
-    let mut builder = SessionBuilder::new();
-    builder = builder.custom_identity(self_identity(&options));
+/// Applies every option that is meaningful for any kind of session builder.
+///
+/// The rust driver exposes some options only on specific builder kinds, so those
+/// are applied by the caller instead.
+fn apply_common_options<K: SessionBuilderKindSupportsKnownNodes>(
+    mut builder: GenericSessionBuilder<K>,
+    options: &SessionOptions,
+) -> ConvertedResult<GenericSessionBuilder<K>> {
+    builder = builder.custom_identity(self_identity(options));
     builder = builder.known_nodes(options.connect_points.as_deref().unwrap_or(&[]));
     if let Some(keyspace) = &options.keyspace {
         builder = builder.use_keyspace(keyspace, false);
@@ -290,10 +296,6 @@ pub(crate) fn configure_session_builder(
                 "There is a check in JS Client constructor that should have prevented only one credential passed"
             )
         }
-    }
-
-    if let Some(ssl_options) = &options.ssl_options {
-        builder = builder.tls_context(configure_ssl(ssl_options)?);
     }
 
     if let Some(allow_list) = options
@@ -320,6 +322,19 @@ pub(crate) fn configure_session_builder(
         exec_profile_builder = exec_profile_builder.retry_policy(policy);
     }
 
+    builder = builder.default_execution_profile_handle(exec_profile_builder.build().into_handle());
+    Ok(builder)
+}
+
+pub(crate) fn configure_session_builder(
+    options: SessionOptions,
+) -> ConvertedResult<SessionBuilder> {
+    let mut builder = apply_common_options(SessionBuilder::new(), &options)?;
+
+    if let Some(ssl_options) = &options.ssl_options {
+        builder = builder.tls_context(configure_ssl(ssl_options)?);
+    }
+
     if let Some(address_translator_config) = options.address_translator_config
         && let Some(address_mapping) = address_translator_config.address_mapping
     {
@@ -331,7 +346,6 @@ pub(crate) fn configure_session_builder(
         builder = builder.address_translator(Arc::new(address_mapping));
     }
 
-    builder = builder.default_execution_profile_handle(exec_profile_builder.build().into_handle());
     Ok(builder)
 }
 

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -429,7 +429,7 @@ fn configure_client_routes_builder(
 }
 
 /// Converts the JS side client routes configuration into the rust driver's one.
-fn convert_client_routes_config(
+pub(crate) fn convert_client_routes_config(
     client_routes_config: ClientRoutesConfig,
 ) -> ConvertedResult<ScyllaClientRoutesConfig> {
     let proxies = client_routes_config

--- a/src/tests/client_routes_proxy_tests.rs
+++ b/src/tests/client_routes_proxy_tests.rs
@@ -1,0 +1,79 @@
+//! Test-only helpers for the client routes integration test.
+//!
+//! These wrap `scylla-proxy`'s `nlb` module - the same fake network load balancer
+//! the upstream rust driver's own client-routes integration tests rely on.
+//!
+//! Only compiled when built with the `client-routes-proxy-tests` feature.
+
+use std::net::SocketAddr;
+use std::sync::OnceLock;
+
+use scylla_proxy::nlb::{NlbFrontend, RunningNlbFrontend};
+use tokio::sync::Mutex;
+
+use crate::errors::{
+    ConvertedError, ConvertedResult, JsResult, make_js_error, with_custom_error_async,
+};
+
+/// A single process-wide slot for tracking running NLBs.
+static RUNNING_NLBS: OnceLock<Mutex<Vec<RunningNlbFrontend>>> = OnceLock::new();
+
+fn running_nlbs() -> &'static Mutex<Vec<RunningNlbFrontend>> {
+    RUNNING_NLBS.get_or_init(|| Mutex::new(Vec::new()))
+}
+
+/// Starts one NLB per given backend address, each forwarding plain TCP to a
+/// single backend - matching how a client routes proxy exposes one node per port.
+///
+/// Returns the address the driver should be told to connect to for each backend
+/// (via a posted `system.client_routes` row), in the same order as `backends`.
+/// Replaces any NLBs started by a previous call.
+#[napi]
+pub async fn tests_start_client_routes_nlbs(backends: Vec<String>) -> JsResult<Vec<String>> {
+    with_custom_error_async(async || {
+        stop_running_nlbs().await;
+
+        let mut listen_addrs = Vec::with_capacity(backends.len());
+        let mut started = Vec::with_capacity(backends.len());
+
+        for backend in backends {
+            let backend_addr: SocketAddr = backend.parse().map_err(|err| {
+                ConvertedError::from(make_js_error(format!(
+                    "Invalid backend address {backend:?}: {err}"
+                )))
+            })?;
+
+            let nlb = NlbFrontend::builder()
+                .listen_addr("127.0.0.1:0".parse().unwrap())
+                .backend(backend_addr)
+                .build()
+                .run()
+                .await
+                .map_err(|err| {
+                    ConvertedError::from(make_js_error(format!(
+                        "Failed to start NLB for {backend_addr}: {err}"
+                    )))
+                })?;
+
+            listen_addrs.push(nlb.listen_addr().to_string());
+            started.push(nlb);
+        }
+
+        *running_nlbs().lock().await = started;
+        ConvertedResult::Ok(listen_addrs)
+    })
+    .await
+}
+
+/// Stops every NLB started by [`tests_start_client_routes_nlbs`].
+#[napi]
+pub async fn tests_stop_client_routes_nlbs() {
+    stop_running_nlbs().await;
+}
+
+async fn stop_running_nlbs() {
+    let previous = std::mem::take(&mut *running_nlbs().lock().await);
+    for nlb in previous {
+        nlb.finish().await;
+    }
+}

--- a/src/tests/client_routes_tests.rs
+++ b/src/tests/client_routes_tests.rs
@@ -1,0 +1,40 @@
+//! Test-only helpers for the client routes bridging layer.
+//!
+//! The routing logic itself lives in the rust driver and is tested there. What
+//! these helpers expose is the part this crate is responsible for: that JS
+//! options are deserialized into the right rust configuration, that the right
+//! session builder kind is selected, and that no option is lost on the way.
+
+use crate::errors::{
+    ConvertedError, ConvertedResult, JsResult, make_js_error, with_custom_error_sync,
+};
+use crate::session::config::{
+    ConfiguredSessionBuilder, SessionOptions, configure_session_builder,
+    convert_client_routes_config,
+};
+
+/// Reports which session builder the given options select: `"default"` or
+/// `"clientRoutes"`. Rejects for configurations the bridge refuses, so the JS
+/// side can assert on the message.
+#[napi]
+pub fn tests_session_builder_mode(options: SessionOptions) -> JsResult<String> {
+    with_custom_error_sync(|| {
+        let mode = match configure_session_builder(options)? {
+            ConfiguredSessionBuilder::Default(_) => "default",
+            ConfiguredSessionBuilder::ClientRoutes(_) => "clientRoutes",
+        };
+        ConvertedResult::Ok(mode.to_owned())
+    })
+}
+
+/// Renders the rust `ClientRoutesConfig` that the given options convert into.
+#[napi]
+pub fn tests_describe_client_routes_config(options: SessionOptions) -> JsResult<String> {
+    with_custom_error_sync(|| {
+        let client_routes_config = options
+            .client_routes_config
+            .ok_or_else(|| ConvertedError::from(make_js_error("clientRoutesConfig was not set")))?;
+        let converted = convert_client_routes_config(client_routes_config)?;
+        ConvertedResult::Ok(format!("{converted:?}"))
+    })
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,3 +1,6 @@
+#[cfg(feature = "client-routes-proxy-tests")]
+pub mod client_routes_proxy_tests;
+pub mod client_routes_tests;
 pub mod js_results_tests;
 pub mod logging_tests;
 pub mod napi_ref_tests;

--- a/src/tests/option_tests.rs
+++ b/src/tests/option_tests.rs
@@ -61,7 +61,8 @@ pub fn tests_check_client_option(options: SessionOptions, test_case: i32) {
                                 socket: "7.3.1.2:960".parse().unwrap()
                             }
                         )])
-                    })
+                    }),
+                    client_routes_config: None
                 }
             )
         }
@@ -80,7 +81,8 @@ pub fn tests_check_client_option(options: SessionOptions, test_case: i32) {
                     ssl_options: None,
                     load_balancing_config: None,
                     retry_policy: None,
-                    address_translator_config: None
+                    address_translator_config: None,
+                    client_routes_config: None
                 }
             )
         }
@@ -99,7 +101,8 @@ pub fn tests_check_client_option(options: SessionOptions, test_case: i32) {
                     ssl_options: None,
                     load_balancing_config: None,
                     retry_policy: None,
-                    address_translator_config: None
+                    address_translator_config: None,
+                    client_routes_config: None
                 }
             )
         }

--- a/test/integration/supported/client-routes-proxy-tests.js
+++ b/test/integration/supported/client-routes-proxy-tests.js
@@ -1,0 +1,255 @@
+"use strict";
+
+// Integration test for the `clientRoutes` client option.
+//
+// This is only runnable against a native addon built with the `client-routes-proxy-tests`
+// Cargo feature enabled (which we enable for all tests with the `build:test` script).
+//
+// Everything about route refreshing (reacting to CLIENT_ROUTES_CHANGE, topology changes,
+// port remapping) is the rust driver's logic and is tested upstream. It is deliberately
+// not retested here.
+
+const assert = require("assert");
+const http = require("http");
+
+const helper = require("../../test-helper.js");
+const Client = require("../../../lib/client.js");
+const rust = require("../../../index");
+
+// The fake NLBs this test routes through live behind the `client-routes-proxy-tests` Cargo
+// feature. Skip the whole suite if the feature is not available rather than failing.
+const builtForTesting =
+    typeof rust.testsStartClientRoutesNlbs === "function" &&
+    typeof rust.testsStopClientRoutesNlbs === "function";
+
+const NODE_COUNT = 3;
+const CONNECTION_ID = "nodejs-driver-client-routes-test";
+const REST_API_PORT = 10000;
+// Returns the coordinator's host id, which is how this test identifies which node
+// actually served a query.
+const WHOAMI_QUERY = "SELECT host_id FROM system.local WHERE key='local'";
+// Used to make a route unusable on purpose.
+const UNRESOLVABLE_HOSTNAME = "unreachable.invalid";
+
+(builtForTesting ? describe : describe.skip)("Client routes", function () {
+    // Generous, but bounded: posting routes retries the REST API for up to ~20s while a
+    // freshly started node warms up, and each test then connects and queries every node.
+    this.timeout(60000);
+
+    helper.setup(NODE_COUNT, { initClient: false });
+
+    let hosts;
+    let nlbAddresses;
+    let supported;
+
+    before(async function () {
+        // Discover every node's real address and host id over a plain connection, and
+        // check whether this build even has system.client_routes.
+        const discoveryClient = new Client(helper.baseOptions);
+        await discoveryClient.connect();
+        hosts = discoveryClient.hosts.values();
+        supported = await hasClientRoutesTable(discoveryClient);
+
+        if (!supported) {
+            return;
+        }
+
+        const realAddresses = hosts.map((host) => host.addressToString());
+        nlbAddresses = await rust.testsStartClientRoutesNlbs(realAddresses);
+    });
+
+    after(async function () {
+        if (supported) {
+            await rust.testsStopClientRoutesNlbs();
+        }
+    });
+
+    beforeEach(function () {
+        if (!supported) {
+            this.skip();
+        }
+    });
+
+    it("reaches every node through an address read from client_routes", async function () {
+        // Each node's route points at its own dedicated NLB. Since the driver is given
+        // no real node address other than the contact point, reaching a node at all
+        // means its address came from system.client_routes and was translated by host id.
+        await postClientRoutes(
+            restApiIpOf(hosts),
+            hosts.map((host, index) =>
+                routeFor(CONNECTION_ID, host, nlbAddresses[index]),
+            ),
+        );
+
+        const client = new Client({
+            contactPoints: [nlbAddresses[0]],
+            clientRoutes: { proxies: [{ connectionId: CONNECTION_ID }] },
+            localDataCenter: helper.baseOptions.localDataCenter,
+        });
+
+        await client.connect();
+        assert.strictEqual(client.hosts.length, NODE_COUNT);
+        const served = await collectCoordinatorHostIds(client, NODE_COUNT);
+        assert.deepStrictEqual(served, hostIdsOf(hosts));
+    });
+
+    it("uses hostnameOverride in place of the hostname from client_routes", async function () {
+        const overrideConnectionId =
+            "nodejs-driver-client-routes-override-test";
+
+        // Every route's hostname is wrong on purpose, so no node is reachable unless
+        // hostnameOverride replaces it.
+        await postClientRoutes(
+            restApiIpOf(hosts),
+            hosts.map((host, index) =>
+                routeFor(
+                    overrideConnectionId,
+                    host,
+                    nlbAddresses[index],
+                    UNRESOLVABLE_HOSTNAME,
+                ),
+            ),
+        );
+
+        const client = new Client({
+            contactPoints: [nlbAddresses[0]],
+            clientRoutes: {
+                proxies: [
+                    {
+                        connectionId: overrideConnectionId,
+                        // Stands in for whatever system.client_routes should have said.
+                        hostnameOverride: "127.0.0.1",
+                    },
+                ],
+            },
+            localDataCenter: helper.baseOptions.localDataCenter,
+        });
+
+        await client.connect();
+        const served = await collectCoordinatorHostIds(client, NODE_COUNT);
+        assert.deepStrictEqual(served, hostIdsOf(hosts));
+    });
+});
+
+/** The sorted host ids of the given nodes. */
+function hostIdsOf(hostList) {
+    return hostList.map((host) => host.hostId.toString()).sort();
+}
+
+/**
+ * Queries repeatedly until every node has served at least one query, and returns the
+ * sorted set of host ids that did. Relies on the load balancing policy spreading
+ * queries around, so it retries rather than assuming one pass is enough.
+ */
+async function collectCoordinatorHostIds(client, expectedCount) {
+    const seen = new Set();
+    const maxAttempts = expectedCount * 50;
+
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+        const result = await client.execute(WHOAMI_QUERY);
+        assert.strictEqual(result.rows.length, 1);
+        seen.add(result.rows[0]["host_id"].toString());
+
+        if (seen.size === expectedCount) {
+            break;
+        }
+    }
+
+    return [...seen].sort();
+}
+
+/** A `system.client_routes` row, in the REST API's schema. */
+function routeFor(connectionId, host, nlbAddress, hostnameOverride) {
+    const [address, port] = splitHostPort(nlbAddress);
+    // Field names match Scylla's REST API schema (snake_case), not JS convention.
+    /* eslint-disable camelcase */
+    return {
+        connection_id: connectionId,
+        host_id: host.hostId.toString(),
+        address: hostnameOverride !== undefined ? hostnameOverride : address,
+        port: Number(port),
+    };
+    /* eslint-enable camelcase */
+}
+
+/** The address of a node to send REST API requests to. */
+function restApiIpOf(hostList) {
+    return splitHostPort(hostList[0].addressToString())[0];
+}
+
+/** Whether this ScyllaDB build has the system.client_routes table at all. */
+async function hasClientRoutesTable(client) {
+    const result = await client.execute(
+        "SELECT table_name FROM system_schema.tables " +
+            "WHERE keyspace_name = 'system' AND table_name = 'client_routes'",
+    );
+    if (result.rows.length > 0) {
+        return true;
+    }
+    helper.trace(
+        "system.client_routes not found - this server does not support client routes, skipping",
+    );
+    return false;
+}
+
+/** Splits an `ip:port` address into its two parts. */
+function splitHostPort(address) {
+    const separatorIndex = address.lastIndexOf(":");
+    return [
+        address.slice(0, separatorIndex),
+        address.slice(separatorIndex + 1),
+    ];
+}
+
+/**
+ * POSTs the given routes to a single node's REST API. ScyllaDB propagates the
+ * routes cluster-wide from there, so posting to just one node is enough - it
+ * mirrors what the upstream rust driver's own client-routes tests do.
+ */
+function postClientRoutes(nodeIp, routes) {
+    const body = JSON.stringify(routes);
+    const maxAttempts = 10;
+    const retryDelayMs = 2000;
+
+    const attempt = (attemptsLeft) =>
+        new Promise((resolve, reject) => {
+            const req = http.request(
+                {
+                    host: nodeIp,
+                    port: REST_API_PORT,
+                    path: "/v2/client-routes",
+                    method: "POST",
+                    headers: {
+                        "Content-Type": "application/json",
+                        "Content-Length": Buffer.byteLength(body),
+                    },
+                },
+                (res) => {
+                    let responseBody = "";
+                    res.on("data", (chunk) => (responseBody += chunk));
+                    res.on("end", () => {
+                        if (res.statusCode === 200 || res.statusCode === 201) {
+                            resolve();
+                        } else {
+                            reject(
+                                new Error(
+                                    `REST API at ${nodeIp}:${REST_API_PORT} returned ${res.statusCode}: ${responseBody}`,
+                                ),
+                            );
+                        }
+                    });
+                },
+            );
+            req.on("error", reject);
+            req.end(body);
+        }).catch((err) => {
+            if (attemptsLeft <= 1) {
+                throw err;
+            }
+            return new Promise((resolve) =>
+                setTimeout(resolve, retryDelayMs),
+            ).then(() => attempt(attemptsLeft - 1));
+        });
+
+    return attempt(maxAttempts);
+}

--- a/test/unit/client-routes-tests.js
+++ b/test/unit/client-routes-tests.js
@@ -1,0 +1,134 @@
+"use strict";
+const assert = require("assert");
+const net = require("node:net");
+const rust = require("../../index");
+const { setRustOptions } = require("../../lib/client-options");
+const {
+    MappingAddressTranslator,
+} = require("../../lib/policies/address-resolution");
+
+const CONNECTION_ID = "nodejs-driver-client-routes-unit-test";
+
+/** Client options selecting client routes mode, merged with `rest`. */
+function withClientRoutes(proxies, rest) {
+    return Object.assign({ clientRoutes: { proxies } }, rest);
+}
+
+const mode = (options) => rust.testsSessionBuilderMode(setRustOptions(options));
+const describeConfig = (options) =>
+    rust.testsDescribeClientRoutesConfig(setRustOptions(options));
+
+describe("Client routes options", function () {
+    describe("builder selection", function () {
+        it("should use the default builder when client routes are not configured", function () {
+            assert.strictEqual(
+                mode({ contactPoints: ["pl.example:9042"] }),
+                "default",
+            );
+        });
+
+        it("should use the client routes builder when proxies are given", function () {
+            assert.strictEqual(
+                mode(
+                    withClientRoutes([{ connectionId: CONNECTION_ID }], {
+                        contactPoints: ["pl.example:9042"],
+                    }),
+                ),
+                "clientRoutes",
+            );
+        });
+    });
+
+    describe("proxy conversion", function () {
+        it("should apply hostnameOverride only to the proxy that declares it", function () {
+            const described = describeConfig(
+                withClientRoutes([
+                    { connectionId: "conn-a" },
+                    {
+                        connectionId: "conn-b",
+                        hostnameOverride: "127.0.0.1",
+                    },
+                ]),
+            );
+
+            assert.deepStrictEqual(
+                described.match(/overridden_hostname: (None|Some\("[^"]*"\))/g),
+                [
+                    "overridden_hostname: None",
+                    'overridden_hostname: Some("127.0.0.1")',
+                ],
+            );
+        });
+
+        it("should treat an empty hostnameOverride as absent", function () {
+            const described = describeConfig(
+                withClientRoutes([
+                    { connectionId: "conn-a", hostnameOverride: "" },
+                ]),
+            );
+
+            assert.match(described, /overridden_hostname: None/);
+        });
+
+        it("should reject an empty proxy list", function () {
+            assert.throws(
+                () => describeConfig({ clientRoutes: { proxies: [] } }),
+                /Invalid clientRoutes configuration/,
+            );
+        });
+
+        it("should reject a proxy without a connectionId, naming its index", function () {
+            assert.throws(
+                () =>
+                    describeConfig({
+                        clientRoutes: {
+                            proxies: [
+                                { connectionId: "conn-a" },
+                                { hostnameOverride: "127.0.0.1" },
+                            ],
+                        },
+                    }),
+                /proxy at index 1 must have a non-empty connectionId/,
+            );
+        });
+    });
+
+    describe("rejected configurations", function () {
+        it("should reject client routes combined with sslOptions", function () {
+            assert.throws(
+                () =>
+                    mode(
+                        withClientRoutes([{ connectionId: CONNECTION_ID }], {
+                            contactPoints: ["pl.example:9042"],
+                            sslOptions: { rejectUnauthorized: false },
+                        }),
+                    ),
+                /cannot be combined with sslOptions/,
+            );
+        });
+
+        it("should reject client routes combined with an address translator", function () {
+            const mapping = new Map([
+                [
+                    new net.SocketAddress({ address: "2.1.3.7", port: 690 }),
+                    new net.SocketAddress({ address: "7.3.1.2", port: 960 }),
+                ],
+            ]);
+
+            assert.throws(
+                () =>
+                    mode(
+                        withClientRoutes([{ connectionId: CONNECTION_ID }], {
+                            contactPoints: ["pl.example:9042"],
+                            policies: {
+                                addressResolution: new MappingAddressTranslator(
+                                    mapping,
+                                ),
+                            },
+                        }),
+                    ),
+                /cannot be combined with an address resolution policy/,
+            );
+        });
+    });
+});


### PR DESCRIPTION
Under PrivateLink nodes addresses must be resolved through their connection ids. The rust driver already does all of this behind its `unstable-client-routes` feature (reads `system.client_routes`, subscribes to `CLIENT_ROUTES_CHANGE`, installs a Host ID based translator), so this PR just enables and exposes it:

- Enabled the `unstable-client-routes` feature on the `scylla` dependency.
- Added a `clientRoutes` client option taking the Scylla Cloud connection ids to read routes for, with an optional per-endpoint `hostnameOverride`.
- Introduced a `ConfiguredSessionBuilder` enum, containing both default `SessionBuilder` and `ClientRoutesSessionBuilder`, since Rust driver defines them separately.
- Rejected `clientRoutes` combined with `policies.addressResolution` or `sslOptions` explicitly rather than dropping them silently.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass tests.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- [x] I have made sure that the type stubs / TS definitions match the JS public API.
- [x] I have adjusted the documentation in `./docs/source/`.
- ~[ ] I have adjusted the migration documentation (removed/changed API) in `./docs/source/migration-guide`.~
- [ ] I added appropriate `Fixes:` annotations to PR description.
