### PR TITLE
Small fixes for metadata

### DIFF
--- a/lib/host.ts
+++ b/lib/host.ts
@@ -254,6 +254,6 @@ export { Host, HostMap };
 // Registers the Host and HostMap constructors, so that Rust can construct fully-formed
 // instances directly when reading cluster metadata.
 // `net.SocketAddress` is registered too, since Rust builds each host's address with it.
-rust.registerSocketAddressCtor(net.SocketAddress as unknown as () => void);
-rust.registerHostCtor(Host as unknown as () => void);
-rust.registerHostMapCtor(HostMap as unknown as () => void);
+rust.registerSocketAddressCtor(net.SocketAddress);
+rust.registerHostCtor(Host);
+rust.registerHostMapCtor(HostMap);

--- a/lib/metadata/index.d.ts
+++ b/lib/metadata/index.d.ts
@@ -1,5 +1,6 @@
 import * as types from "../types";
 import { EmptyCallback, Host, token, ValueCallback } from "../../";
+import { CqlType } from "../../index";
 import dataTypes = types.dataTypes;
 import Uuid = types.Uuid;
 import InetAddress = types.InetAddress;
@@ -45,9 +46,30 @@ export interface DataTypeInfo {
   };
 }
 
+/**
+ * Describes CQL column type information.
+ *
+ * The `info` field varies depending on the type code:
+ * - Simple types: `info` is `null`
+ * - List/Set: `info` is a `ColumnInfo` for the element type
+ * - Map: `info` is a tuple `[ColumnInfo, ColumnInfo]` for key and value types
+ * - Tuple: `info` is an array of `ColumnInfo` for each element
+ * - UDT: `info` is a `UdtInfo` with name and fields
+ * - Vector (custom): `info` is a tuple `[ColumnInfo, number]` for element type and dimension
+ * - Other custom: `info` is a string
+ */
 export interface ColumnInfo {
-  name: string;
-  type: DataTypeInfo;
+  code: CqlType;
+  info:
+    | null
+    | ColumnInfo
+    | [ColumnInfo, ColumnInfo]
+    | ColumnInfo[]
+    | UdtInfo
+    | [ColumnInfo, number]
+    | string;
+  options?: ColumnInfoOptions;
+  customTypeName?: string;
 }
 
 export enum ColumnKind {

--- a/lib/metadata/index.d.ts
+++ b/lib/metadata/index.d.ts
@@ -25,6 +25,17 @@ export interface ClientState {
   toString(): string;
 }
 
+export interface ColumnInfoOptions {
+  frozen?: boolean;
+  reversed?: boolean;
+}
+
+export interface UdtInfo {
+  name: string;
+  keyspace: string;
+  fields: UdtField[];
+}
+
 export interface DataTypeInfo {
   code: dataTypes;
   info: string | DataTypeInfo | DataTypeInfo[];

--- a/lib/metadata/index.d.ts
+++ b/lib/metadata/index.d.ts
@@ -37,15 +37,6 @@ export interface UdtInfo {
   fields: UdtField[];
 }
 
-export interface DataTypeInfo {
-  code: dataTypes;
-  info: string | DataTypeInfo | DataTypeInfo[];
-  options: {
-    frozen: boolean;
-    reversed: boolean;
-  };
-}
-
 /**
  * Describes CQL column type information.
  *

--- a/lib/metadata/index.d.ts
+++ b/lib/metadata/index.d.ts
@@ -80,7 +80,7 @@ export enum ColumnKind {
 }
 
 export interface ColumnMetadata {
-  type: string;
+  type: ColumnInfo;
   kind: ColumnKind;
 }
 
@@ -144,7 +144,7 @@ export interface SchemaFunction {
 
 export interface UdtField {
   name: string;
-  type: DataTypeInfo;
+  type: ColumnInfo;
 }
 
 export interface Udt {

--- a/lib/metadata/keyspace-metadata.js
+++ b/lib/metadata/keyspace-metadata.js
@@ -69,20 +69,20 @@ class Strategy {
      * Replication factors of datacenters with given names, i.e. how many replicas of each piece
      * of data there are in each datacenter.
      * (only set when {@link kind} is {@link StrategyKind.NetworkTopologyStrategy}).
-     * @type {Object.<String, number>?}
+     * @type {Object.<string, number>?}
      */
     datacenterRepfactors;
 
     /**
      * Name of the strategy (only set when {@link kind} is {@link StrategyKind.Other}).
-     * @type {String?}
+     * @type {string?}
      */
     name;
 
     /**
      * Additional parameters of the strategy, which the driver does not understand.
      * (only set when {@link kind} is {@link StrategyKind.Other}).
-     * @type {Object.<String, String>?}
+     * @type {Object.<string, string>?}
      */
     data;
 }
@@ -106,19 +106,19 @@ class KeyspaceMetadata {
 
     /**
      * Tables in the keyspace, keyed by table name.
-     * @type {Object.<String, TableMetadata>}
+     * @type {Object.<string, TableMetadata>}
      */
     tables;
 
     /**
      * Materialized views in the keyspace, keyed by view name.
-     * @type {Object.<String, MaterializedView>}
+     * @type {Object.<string, MaterializedView>}
      */
     views;
 
     /**
      * User-defined types in the keyspace, keyed by type name.
-     * @type {Object.<String, Udt>}
+     * @type {Object.<string, Udt>}
      */
     udts;
 }

--- a/lib/metadata/materialized-view.js
+++ b/lib/metadata/materialized-view.js
@@ -19,7 +19,7 @@ class MaterializedView {
 
     /**
      * Name of the table.
-     * @type {String}
+     * @type {string}
      */
     tableName;
 }

--- a/lib/metadata/table-metadata.js
+++ b/lib/metadata/table-metadata.js
@@ -50,27 +50,27 @@ class TableMetadata {
      * Columns that constitute the table, keyed by column name.
      *
      * This type does not contain information about the order of the columns in the table.
-     * @type {Object.<String, ColumnMetadata>}
+     * @type {Object.<string, ColumnMetadata>}
      */
     columns;
 
     /**
      * Names of the columns that constitute the partition key.
      * All names are guaranteed to be present in {@link columns}.
-     * @type {Array.<String>}
+     * @type {Array.<string>}
      */
     partitionKey;
 
     /**
      * Names of the columns that constitute the clustering key.
      * All names are guaranteed to be present in {@link columns}.
-     * @type {Array.<String>}
+     * @type {Array.<string>}
      */
     clusteringKey;
 
     /**
      * Name of the partitioner used by the table, or null if not set.
-     * @type {String|null}
+     * @type {string|null}
      */
     partitioner;
 }

--- a/lib/metadata/user-defined-type.js
+++ b/lib/metadata/user-defined-type.js
@@ -12,7 +12,7 @@ const { ColumnInfo } = require("../types/cql-utils");
 class UdtField {
     /**
      * Name of the field.
-     * @type {String}
+     * @type {string}
      */
     name;
 
@@ -31,13 +31,13 @@ class Udt {
     /**
      * Definition of a user-defined type (UDT).
      * UDT is composed of fields, each with a name and an optional value of its own type.
-     * @type {String}
+     * @type {string}
      */
     name;
 
     /**
      * Name of the keyspace the type belongs to.
-     * @type {String}
+     * @type {string}
      */
     keyspace;
 

--- a/lib/types/cql-utils.ts
+++ b/lib/types/cql-utils.ts
@@ -1,6 +1,7 @@
 import { ComplexType, CqlType } from "../../index";
 import type { CqlValue } from "../../main";
 import Encoder = require("../encoder");
+import { UdtField } from "../metadata/user-defined-type";
 
 /** Options grouping for column information.
  * This option grouping is present to make this interface backward compatible. */
@@ -15,12 +16,6 @@ export interface ColumnInfoOptions {
     // We are not using this field at the moment.
     // It's likely we will want to remove this field at some point
     reversed?: boolean;
-}
-
-/** Single field of the user-defined type - (name, type) pair */
-export interface UdtField {
-    name: string;
-    type: ColumnInfo;
 }
 
 /** Definition of a user-defined type (UDT).

--- a/lib/types/cql-utils.ts
+++ b/lib/types/cql-utils.ts
@@ -74,10 +74,12 @@ export class ColumnInfo {
         code: CqlType,
         info: ColumnInfo["info"] = null,
         customTypeName?: string,
+        options?: ColumnInfoOptions,
     ) {
         this.code = code;
         this.info = info;
         this.customTypeName = customTypeName;
+        this.options = options;
     }
 }
 
@@ -115,12 +117,19 @@ export function convertComplexType(type: ComplexType): ColumnInfo {
                 return new ColumnInfo(
                     type.baseType.valueOf(),
                     convertComplexType(type.subtype1),
+                    undefined,
+                    { frozen: type.frozen },
                 );
             case CqlType.Map:
-                return new ColumnInfo(type.baseType.valueOf(), [
-                    convertComplexType(type.subtype1),
-                    convertComplexType(type.subtype2),
-                ]);
+                return new ColumnInfo(
+                    type.baseType.valueOf(),
+                    [
+                        convertComplexType(type.subtype1),
+                        convertComplexType(type.subtype2),
+                    ],
+                    undefined,
+                    { frozen: type.frozen },
+                );
             case CqlType.Vector:
                 return new ColumnInfo(
                     CqlType.Custom,
@@ -128,16 +137,21 @@ export function convertComplexType(type: ComplexType): ColumnInfo {
                     "vector",
                 );
             case CqlType.Udt:
-                return new ColumnInfo(type.baseType.valueOf(), {
-                    name: type.name,
-                    keyspace: type.keyspace,
-                    fields: type.udt_types.map(
-                        (typ: ComplexType, index: number) => ({
-                            type: convertComplexType(typ),
-                            name: type.udt_name[index],
-                        }),
-                    ),
-                });
+                return new ColumnInfo(
+                    type.baseType.valueOf(),
+                    {
+                        name: type.name,
+                        keyspace: type.keyspace,
+                        fields: type.udt_types.map(
+                            (typ: ComplexType, index: number) => ({
+                                type: convertComplexType(typ),
+                                name: type.udt_name[index],
+                            }),
+                        ),
+                    },
+                    undefined,
+                    { frozen: type.frozen },
+                );
             case CqlType.Tuple:
                 return new ColumnInfo(
                     type.baseType.valueOf(),

--- a/lib/types/cql-utils.ts
+++ b/lib/types/cql-utils.ts
@@ -23,6 +23,8 @@ export interface ColumnInfoOptions {
 export interface UdtInfo {
     /** Name of the user-defined type. */
     name: string;
+    /** Keyspace the user-defined type is defined in. */
+    keyspace: string;
     fields: UdtField[];
 }
 
@@ -128,6 +130,7 @@ export function convertComplexType(type: ComplexType): ColumnInfo {
             case CqlType.Udt:
                 return new ColumnInfo(type.baseType.valueOf(), {
                     name: type.name,
+                    keyspace: type.keyspace,
                     fields: type.udt_types.map(
                         (typ: ComplexType, index: number) => ({
                             type: convertComplexType(typ),

--- a/main.d.ts
+++ b/main.d.ts
@@ -157,9 +157,9 @@ export class Client extends events.EventEmitter {
 export interface HostMap extends events.EventEmitter {
   length: number;
 
-  forEach(callback: (value: Host, key: string) => void): void;
+  forEach(callback: (value: Host, key: Uuid) => void): void;
 
-  get(key: string): Host | undefined;
+  get(key: Uuid | Buffer | net.SocketAddress | string): Host | undefined;
 
   keys(): Uuid[];
 

--- a/src/types/type_wrappers.rs
+++ b/src/types/type_wrappers.rs
@@ -81,6 +81,7 @@ impl ToNapiValue for ComplexType<'_> {
             ColumnType::Native(native_type) => {
                 obj.set_named_property(
                     base_type_name,
+                    #[deny(clippy::wildcard_enum_match_arm)]
                     match native_type {
                         NativeType::Ascii => CqlType::Ascii,
                         NativeType::Boolean => CqlType::Boolean,
@@ -108,8 +109,11 @@ impl ToNapiValue for ComplexType<'_> {
                         NativeType::Timeuuid => CqlType::Timeuuid,
                         NativeType::Uuid => CqlType::Uuid,
                         NativeType::Varint => CqlType::Varint,
-                        other => {
-                            unimplemented!("Missing implementation for CQL native type {:?}", other)
+                        _ => {
+                            unimplemented!(
+                                "Missing implementation for CQL native type {:?}",
+                                native_type
+                            )
                         }
                     },
                 )?;

--- a/src/utils/js_ctor.rs
+++ b/src/utils/js_ctor.rs
@@ -89,7 +89,10 @@ macro_rules! define_js_ctor {
         /// and once on the main thread), by the corresponding module on load, before any cluster metadata
         /// is accessed in that environment.
         #[napi]
-        pub fn $register_fn(ctor: Function<(), ()>, env: Env) -> napi::Result<()> {
+        pub fn $register_fn(
+            #[napi(ts_arg_type = "new (...args: any[]) => any")] ctor: Function<(), ()>,
+            env: Env,
+        ) -> napi::Result<()> {
             let ctor_ref = ctor.create_ref()?;
             let key = env.raw() as usize;
             {


### PR DESCRIPTION
- Make match for ComplexType exhaustive.
- Fix Udt declaration to match that in user-defined-type.js. Remove UdtField duplicate declaration and import it in cql-utils.ts. Add keyspace field to UdtInfo.
- Preserve type.frozen during conversion from ComplexType to ColumnInfo.
- Redeclare ColumnInfo, ColumnInfoOptions and UdtInfo for UdtField and ColumnMetadata. Remove obsolete DataTypeInfo and previous ColumnInfo declarations.
- Type register_*_ctor’s JS constructor argument.
- Rewrite HostMap declarations to match actual implementation.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~[ ] I added relevant tests for new features and bug fixes.~
- [x] All commits compile, pass static checks and pass tests.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~[ ] I have provided docstrings for the public items that I want to introduce.~
- [x] I have made sure that the type stubs / TS definitions match the JS public API.
- ~[ ] I have adjusted the documentation in `./docs/source/`.~
- ~[ ] I have adjusted the migration documentation (removed/changed API) in `./docs/source/migration-guide`.~
- ~[ ] I added appropriate `Fixes:` annotations to PR description.~
