### PR TITLE
Add vector search example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -29,6 +29,10 @@ Alternatively you can run just a specific example by providing the path to it:
 node ./basic/basic-connect.js
 ```
 
+### Vector search example
+
+[`vector/vector-search-ann.js`](vector/vector-search-ann.js) is not run by `npm run examples`, because it needs more than the other examples do: a ScyllaDB cluster with [vector search](https://cloud.docs.scylladb.com/stable/vector-search/) enabled.
+
 ## Code samples
 
 Part of the examples listed here are from the [datastax driver repository](https://github.com/datastax/nodejs-driver/tree/master).
@@ -49,6 +53,7 @@ Those examples are present in this directory and have the `.broken` in the name 
   - [Working with user-defined types (UDT)](udt/udt-insert-select.js)
   - [Working with tuples](tuple/tuple-insert-select.js)
   - [Working with vectors](vector/vector-insert-select.js)
+  - [Vector search with ANN similarity queries](vector/vector-search-ann.js)
 <!-- - Query tracing
   - [Retrieving the trace of a query request](tracing/retrieve-query-trace.js) -->
 - Concurrent execution

--- a/examples/README.md
+++ b/examples/README.md
@@ -48,6 +48,7 @@ Those examples are present in this directory and have the `.broken` in the name 
 - Data types
   - [Working with user-defined types (UDT)](udt/udt-insert-select.js)
   - [Working with tuples](tuple/tuple-insert-select.js)
+  - [Working with vectors](vector/vector-insert-select.js)
 <!-- - Query tracing
   - [Retrieving the trace of a query request](tracing/retrieve-query-trace.js) -->
 - Concurrent execution

--- a/examples/runner.js
+++ b/examples/runner.js
@@ -11,8 +11,8 @@ const path = require("path");
  * For description of datastax examples see see ./DataStax/README.md and subdirectories for more information.
  */
 
-// Name of the files to ignore as examples, no matter of their path
-const ignoredFiles = ["util.js"];
+// Name of the files to ignore as examples, no matter of their path.
+const ignoredFiles = ["util.js", "vector-search-ann.js"];
 
 // Timeout for each example in ms
 const timeoutValue = 10000;

--- a/examples/vector/vector-insert-select.js
+++ b/examples/vector/vector-insert-select.js
@@ -1,0 +1,70 @@
+"use strict";
+const cassandra = require("@scylladb/driver");
+const { getClientArgs } = require("../util");
+
+const client = new cassandra.Client(getClientArgs());
+
+/**
+ * Creates a table with a vector column, inserts a row and selects a row.
+ */
+async function example() {
+    await client.connect();
+
+    await client.execute(
+        "CREATE KEYSPACE IF NOT EXISTS examples WITH replication =" +
+            "{'class': 'NetworkTopologyStrategy', 'replication_factor': '1' }",
+    );
+
+    await client.execute(
+        "CREATE TABLE IF NOT EXISTS examples.vector_comments " +
+            "(id uuid PRIMARY KEY, comment text, comment_vector vector<float, 5>)",
+    );
+
+    // A Vector can be built from a plain Array (with an explicit subtype)...
+    const commentVector = new cassandra.types.Vector(
+        [0.12, 0.34, 0.56, 0.78, 0.91],
+        "float",
+    );
+    const id1 = cassandra.types.Uuid.random();
+
+    console.log(`Inserting comment for id ${id1} from plain Array`);
+    await client.execute(
+        "INSERT INTO examples.vector_comments (id, comment, comment_vector) VALUES (?, ?, ?)",
+        [id1, "Great product, fast shipping!", commentVector],
+        { prepare: true },
+    );
+
+    const result = await client.execute(
+        "SELECT comment, comment_vector FROM examples.vector_comments WHERE id = ?",
+        [id1],
+        { prepare: true },
+    );
+    const row = result.first();
+    console.log(`Retrieved comment for id ${id1}: "${row["comment"]}"`);
+    console.log(`Retrieved vector for id ${id1}: ${row["comment_vector"]}`);
+
+    // ...or from a Float32Array.
+    const commentVectorArray = new Float32Array([0.11, 0.22, 0.33, 0.44, 0.55]);
+    const id2 = cassandra.types.Uuid.random();
+
+    console.log(`Inserting comment for id ${id2} from Float32Array`);
+    await client.execute(
+        "INSERT INTO examples.vector_comments (id, comment, comment_vector) VALUES (?, ?, ?)",
+        [id2, "Exactly as described", commentVectorArray],
+        { prepare: true },
+    );
+
+    const result2 = await client.execute(
+        "SELECT comment, comment_vector FROM examples.vector_comments WHERE id = ?",
+        [id2],
+        { prepare: true },
+    );
+    const row2 = result2.first();
+    console.log(`Retrieved comment for id ${id2}: "${row2["comment"]}"`);
+    console.log(`Retrieved vector for id ${id2}: ${row2["comment_vector"]}`);
+}
+
+example().catch(function (err) {
+    console.error("There was an error", err);
+    process.exitCode = 1;
+});

--- a/examples/vector/vector-search-ann.js
+++ b/examples/vector/vector-search-ann.js
@@ -1,0 +1,102 @@
+"use strict";
+const cassandra = require("@scylladb/driver");
+const { getClientArgs } = require("../util");
+
+const client = new cassandra.Client(getClientArgs());
+
+const comments = [
+    { text: "Great product, fast shipping!", vector: [0.9, 0.1, 0.0] },
+    { text: "Arrived quickly, very happy", vector: [0.8, 0.2, 0.0] },
+    { text: "The colour is completely wrong", vector: [0.1, 0.9, 0.0] },
+    { text: "Broke after a single use", vector: [0.0, 0.2, 0.9] },
+];
+
+// The embedding we search with. Closest in meaning to the "fast shipping"
+// comments, so those are the ones the ANN query should return first.
+const queryVector = [0.95, 0.05, 0.0];
+
+/**
+ * Stores comment embeddings in a `vector` column and finds the ones most
+ * similar to a query embedding with an `ORDER BY ... ANN OF` query.
+ */
+async function example() {
+    await client.connect();
+
+    await client.execute(
+        "CREATE KEYSPACE IF NOT EXISTS examples WITH replication =" +
+            "{'class': 'NetworkTopologyStrategy', 'replication_factor': '1' }",
+    );
+
+    await client.execute(
+        "CREATE TABLE IF NOT EXISTS examples.vector_search_comments " +
+            "(id uuid PRIMARY KEY, comment text, comment_vector vector<float, 3>)",
+    );
+
+    console.log("Inserting comments");
+    for (const comment of comments) {
+        await client.execute(
+            "INSERT INTO examples.vector_search_comments (id, comment, comment_vector) " +
+                "VALUES (?, ?, ?)",
+            [
+                cassandra.types.Uuid.random(),
+                comment.text,
+                new cassandra.types.Vector(comment.vector, "float"),
+            ],
+            { prepare: true },
+        );
+    }
+
+    await client.execute(
+        "CREATE CUSTOM INDEX IF NOT EXISTS comment_ann_index " +
+            "ON examples.vector_search_comments (comment_vector) " +
+            "USING 'vector_index' WITH OPTIONS = { 'similarity_function': 'COSINE' }",
+    );
+
+    const matches = await annSearch(
+        "SELECT comment FROM examples.vector_search_comments " +
+            "ORDER BY comment_vector ANN OF ? LIMIT 2",
+        [new cassandra.types.Vector(queryVector, "float")],
+    );
+
+    console.log("Comments most similar to the query embedding:");
+    for (const match of matches) {
+        console.log(`  ${match["comment"]}`);
+    }
+}
+
+example().catch(function (err) {
+    console.error("There was an error", err);
+    process.exitCode = 1;
+});
+
+// Vector search takes a moment to become usable: the Vector Store service has
+// to be reachable, and it builds its index asynchronously.
+const vectorSearchTimeout = 6000;
+
+/**
+ * Runs an ANN query, waiting for vector search to become available.
+ * @returns {Promise<Array<Row>>}
+ */
+async function annSearch(query, params) {
+    const deadline = Date.now() + vectorSearchTimeout;
+    let lastError;
+    for (;;) {
+        try {
+            const result = await client.execute(query, params, {
+                prepare: true,
+            });
+            if (result.rows.length > 0) {
+                return result.rows;
+            }
+        } catch (err) {
+            // Report the last failure as the cause if we run out of time.
+            lastError = err;
+        }
+        if (Date.now() > deadline) {
+            throw new Error("Vector search did not become available.", {
+                cause: lastError,
+            });
+        }
+        await new Promise((resolve) => setTimeout(resolve, 250));
+    }
+}

--- a/test/test-helper.js
+++ b/test/test-helper.js
@@ -1638,6 +1638,28 @@ const dataProvider = [
         value: ["ab", "b", "cde"],
     },
     {
+        subtypeString: "ascii",
+        typeInfo: {
+            code: types.dataTypes.custom,
+            customTypeName: "vector",
+            info: [{ code: types.dataTypes.ascii }, 3],
+        },
+        value: ["ab", "b", "cde"],
+    },
+    {
+        subtypeString: "varint",
+        typeInfo: {
+            code: types.dataTypes.custom,
+            customTypeName: "vector",
+            info: [{ code: types.dataTypes.varint }, 3],
+        },
+        value: [
+            types.Integer.fromString("-1"),
+            types.Integer.fromString("0"),
+            types.Integer.fromString("12345678901234567890"),
+        ],
+    },
+    {
         subtypeString: "bigint",
         typeInfo: {
             code: types.dataTypes.custom,

--- a/test/test-helper.js
+++ b/test/test-helper.js
@@ -1827,9 +1827,7 @@ const dataProviderWithCollections = dataProvider
             },
             value: data.value.map((value) => [value, value, value]),
         },
-        // TODO: Fails due to https://github.com/scylladb/scylladb/issues/26704
-        // Fix, once the change is ported to ccm.
-        /* // vector<map<int, subtype>, 3>
+        // vector<map<int, subtype>, 3>
         {
             subtypeString: "map<int, " + data.subtypeString + ">",
             typeInfo: {
@@ -1872,8 +1870,8 @@ const dataProviderWithCollections = dataProvider
                 ],
                 customTypeName: "vector",
             },
-            value: data.value.map((value) => [value, value, value]),
-        }, */
+            value: data.value.map((value) => [value]),
+        },
         // vector<tuple<subtype, subtype>, 3>
         {
             subtypeString:


### PR DESCRIPTION
Vector search needs nothing new from this driver: the CQL vector type is already supported, and `ORDER BY ... ANN OF ?` is plain CQL sent through the normal `execute()` path. This PR proves it with a minimal working example.

`examples/vector/vector-search-ann.js` stores comment embeddings in a `vector<float, 3>` column, creates a vector index, and runs an ANN similarity query.
`examples/vector/vector-insert-select.js` covers plain vector column insert/select.

Enabled tests for map, set, ascii, and varint variants inside a vector.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~[ ] I added relevant tests for new features and bug fixes.~
- [x] All commits compile, pass static checks and pass tests.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~[ ] I have provided docstrings for the public items that I want to introduce.~
- ~[ ] I have made sure that the type stubs / TS definitions match the JS public API.~
- ~[ ] I have adjusted the documentation in `./docs/source/`.~
- ~[ ] I have adjusted the migration documentation (removed/changed API) in `./docs/source/migration-guide`.~
- [ ] I added appropriate `Fixes:` annotations to PR description.
