### PR TITLE
Fix type hints parsing

### DIFF
--- a/lib/types/index.js
+++ b/lib/types/index.js
@@ -90,6 +90,33 @@ consistencyToString[consistencies.localOne] = "LOCAL_ONE";
  * @property {Number} udt User-defined type.
  * @property {Number} tuple A sequence of values.
  */
+
+/**
+ * Splits the comma separated arguments of a parameterized type name, ignoring
+ * the commas that belong to the arguments themselves.
+ *
+ * @param {String} args Everything between the outermost angle brackets.
+ * @returns {Array<String>} The arguments, trimmed.
+ */
+function splitTypeArgs(args) {
+    const result = [];
+    let depth = 0;
+    let start = 0;
+    for (let i = 0; i < args.length; i++) {
+        const char = args[i];
+        if (char === "<") {
+            depth++;
+        } else if (char === ">") {
+            depth--;
+        } else if (char === "," && depth === 0) {
+            result.push(args.substring(start, i).trim());
+            start = i + 1;
+        }
+    }
+    result.push(args.substring(start).trim());
+    return result;
+}
+
 const dataTypes = {
     custom: 0x0000,
     ascii: 0x0001,
@@ -133,15 +160,19 @@ const dataTypes = {
                     info: this.getByName(listMatches[2]),
                 };
             }
-            const mapMatches = /^(map)< *(.+) *, *(.+)>$/.exec(name);
+            const mapMatches = /^map<(.+)>$/.exec(name);
             if (mapMatches) {
-                return {
-                    code: this[mapMatches[1]],
-                    info: [
-                        this.getByName(mapMatches[2]),
-                        this.getByName(mapMatches[3]),
-                    ],
-                };
+                const args = splitTypeArgs(mapMatches[1]);
+                if (args.length === 2) {
+                    const [keyType, valueType] = args;
+                    return {
+                        code: this.map,
+                        info: [
+                            this.getByName(keyType),
+                            this.getByName(valueType),
+                        ],
+                    };
+                }
             }
             const udtMatches = /^(udt)<(.+)>$/.exec(name);
             if (udtMatches) {
@@ -153,18 +184,25 @@ const dataTypes = {
                 // tuple info as an array of types
                 return {
                     code: this[tupleMatches[1]],
-                    info: tupleMatches[2].split(",").map(function (x) {
-                        return this.getByName(x.trim());
+                    info: splitTypeArgs(tupleMatches[2]).map(function (x) {
+                        return this.getByName(x);
                     }, this),
                 };
             }
-            const vectorMatches = /^vector<\s*(.+)\s*,\s*(\d+)\s*>$/.exec(name);
+            const vectorMatches = /^vector<(.+)>$/.exec(name);
             if (vectorMatches) {
-                return {
-                    code: this.custom,
-                    customTypeName: "vector",
-                    info: [this.getByName(vectorMatches[1]), parseInt(vectorMatches[2], 10)]
-                };
+                const args = splitTypeArgs(vectorMatches[1]);
+                const [subtype, dimension] = args;
+                if (args.length === 2 && /^\d+$/.test(dimension)) {
+                    return {
+                        code: this.custom,
+                        customTypeName: "vector",
+                        info: [
+                            this.getByName(subtype),
+                            parseInt(dimension, 10),
+                        ],
+                    };
+                }
             }
         }
         const typeInfo = { code: this[name] };
@@ -273,7 +311,7 @@ const responseErrorCodes = {
 
 /**
  * Unset representation.
- * 
+ *
  * Use this field if you want to set a parameter to `unset`. Valid for Cassandra 2.2 and above.
  */
 const unset = Object.freeze({ unset: true });

--- a/test/unit/encoder-tests.js
+++ b/test/unit/encoder-tests.js
@@ -2138,6 +2138,377 @@ describe("encoder", function () {
         });
     });
 
+    // Text type hints given by the user are resolved here, unlike the type
+    // names sent by the server, which go through #parseTypeName().
+    describe("dataTypes.getByName()", function () {
+        it("should parse scalar types", function () {
+            [
+                "ascii",
+                "bigint",
+                "blob",
+                "boolean",
+                "counter",
+                "date",
+                "decimal",
+                "double",
+                "duration",
+                "float",
+                "inet",
+                "int",
+                "smallint",
+                "text",
+                "time",
+                "timestamp",
+                "timeuuid",
+                "tinyint",
+                "uuid",
+                "varchar",
+                "varint",
+            ].forEach((name) => {
+                assert.deepEqual(dataTypes.getByName(name), {
+                    code: dataTypes[name],
+                });
+            });
+        });
+
+        it("should parse partial hints of parameterized types", function () {
+            ["list", "set", "map", "tuple", "udt"].forEach((name) => {
+                assert.deepEqual(dataTypes.getByName(name), {
+                    code: dataTypes[name],
+                });
+            });
+        });
+
+        it("should be case insensitive", function () {
+            assert.deepEqual(dataTypes.getByName("Int"), {
+                code: dataTypes.int,
+            });
+            assert.deepEqual(
+                dataTypes.getByName("VECTOR<FLOAT, 3>"),
+                dataTypes.getByName("vector<float, 3>"),
+            );
+        });
+
+        it("should ignore whitespace around the arguments", function () {
+            assert.deepEqual(
+                dataTypes.getByName("vector< float , 3 >"),
+                dataTypes.getByName("vector<float,3>"),
+            );
+            assert.deepEqual(
+                dataTypes.getByName("map< int , text >"),
+                dataTypes.getByName("map<int,text>"),
+            );
+        });
+
+        const parameterized = [
+            [
+                "list<int>",
+                { code: dataTypes.list, info: { code: dataTypes.int } },
+            ],
+            [
+                "set<text>",
+                { code: dataTypes.set, info: { code: dataTypes.text } },
+            ],
+            [
+                "list<map<int, text>>",
+                {
+                    code: dataTypes.list,
+                    info: {
+                        code: dataTypes.map,
+                        info: [
+                            { code: dataTypes.int },
+                            { code: dataTypes.text },
+                        ],
+                    },
+                },
+            ],
+            [
+                "list<vector<float, 3>>",
+                {
+                    code: dataTypes.list,
+                    info: {
+                        code: dataTypes.custom,
+                        customTypeName: "vector",
+                        info: [{ code: dataTypes.float }, 3],
+                    },
+                },
+            ],
+            [
+                "set<vector<float, 3>>",
+                {
+                    code: dataTypes.set,
+                    info: {
+                        code: dataTypes.custom,
+                        customTypeName: "vector",
+                        info: [{ code: dataTypes.float }, 3],
+                    },
+                },
+            ],
+            ["udt<my_udt>", { code: dataTypes.udt, info: "my_udt" }],
+            [
+                "map<int, text>",
+                {
+                    code: dataTypes.map,
+                    info: [{ code: dataTypes.int }, { code: dataTypes.text }],
+                },
+            ],
+            [
+                "map<int, map<int, text>>",
+                {
+                    code: dataTypes.map,
+                    info: [
+                        { code: dataTypes.int },
+                        {
+                            code: dataTypes.map,
+                            info: [
+                                { code: dataTypes.int },
+                                { code: dataTypes.text },
+                            ],
+                        },
+                    ],
+                },
+            ],
+            [
+                "map<map<int, text>, int>",
+                {
+                    code: dataTypes.map,
+                    info: [
+                        {
+                            code: dataTypes.map,
+                            info: [
+                                { code: dataTypes.int },
+                                { code: dataTypes.text },
+                            ],
+                        },
+                        { code: dataTypes.int },
+                    ],
+                },
+            ],
+            [
+                "map<int, tuple<int, text>>",
+                {
+                    code: dataTypes.map,
+                    info: [
+                        { code: dataTypes.int },
+                        {
+                            code: dataTypes.tuple,
+                            info: [
+                                { code: dataTypes.int },
+                                { code: dataTypes.text },
+                            ],
+                        },
+                    ],
+                },
+            ],
+            [
+                "map<int, vector<float, 3>>",
+                {
+                    code: dataTypes.map,
+                    info: [
+                        { code: dataTypes.int },
+                        {
+                            code: dataTypes.custom,
+                            customTypeName: "vector",
+                            info: [{ code: dataTypes.float }, 3],
+                        },
+                    ],
+                },
+            ],
+            [
+                "map<tuple<int, text>, list<int>>",
+                {
+                    code: dataTypes.map,
+                    info: [
+                        {
+                            code: dataTypes.tuple,
+                            info: [
+                                { code: dataTypes.int },
+                                { code: dataTypes.text },
+                            ],
+                        },
+                        { code: dataTypes.list, info: { code: dataTypes.int } },
+                    ],
+                },
+            ],
+
+            [
+                "tuple<int, text>",
+                {
+                    code: dataTypes.tuple,
+                    info: [{ code: dataTypes.int }, { code: dataTypes.text }],
+                },
+            ],
+            [
+                "tuple<int, text, boolean>",
+                {
+                    code: dataTypes.tuple,
+                    info: [
+                        { code: dataTypes.int },
+                        { code: dataTypes.text },
+                        { code: dataTypes.boolean },
+                    ],
+                },
+            ],
+            [
+                "tuple<tuple<int, int>, int>",
+                {
+                    code: dataTypes.tuple,
+                    info: [
+                        {
+                            code: dataTypes.tuple,
+                            info: [
+                                { code: dataTypes.int },
+                                { code: dataTypes.int },
+                            ],
+                        },
+                        { code: dataTypes.int },
+                    ],
+                },
+            ],
+            [
+                "tuple<map<int, text>, int>",
+                {
+                    code: dataTypes.tuple,
+                    info: [
+                        {
+                            code: dataTypes.map,
+                            info: [
+                                { code: dataTypes.int },
+                                { code: dataTypes.text },
+                            ],
+                        },
+                        { code: dataTypes.int },
+                    ],
+                },
+            ],
+            [
+                "tuple<vector<float, 3>, int>",
+                {
+                    code: dataTypes.tuple,
+                    info: [
+                        {
+                            code: dataTypes.custom,
+                            customTypeName: "vector",
+                            info: [{ code: dataTypes.float }, 3],
+                        },
+                        { code: dataTypes.int },
+                    ],
+                },
+            ],
+            [
+                "tuple<list<int>, set<text>>",
+                {
+                    code: dataTypes.tuple,
+                    info: [
+                        { code: dataTypes.list, info: { code: dataTypes.int } },
+                        { code: dataTypes.set, info: { code: dataTypes.text } },
+                    ],
+                },
+            ],
+
+            [
+                "vector<float, 3>",
+                {
+                    code: dataTypes.custom,
+                    customTypeName: "vector",
+                    info: [{ code: dataTypes.float }, 3],
+                },
+            ],
+            [
+                "vector<list<int>, 3>",
+                {
+                    code: dataTypes.custom,
+                    customTypeName: "vector",
+                    info: [
+                        { code: dataTypes.list, info: { code: dataTypes.int } },
+                        3,
+                    ],
+                },
+            ],
+            [
+                "vector<map<int, text>, 3>",
+                {
+                    code: dataTypes.custom,
+                    customTypeName: "vector",
+                    info: [
+                        {
+                            code: dataTypes.map,
+                            info: [
+                                { code: dataTypes.int },
+                                { code: dataTypes.text },
+                            ],
+                        },
+                        3,
+                    ],
+                },
+            ],
+            [
+                "vector<tuple<int, text>, 3>",
+                {
+                    code: dataTypes.custom,
+                    customTypeName: "vector",
+                    info: [
+                        {
+                            code: dataTypes.tuple,
+                            info: [
+                                { code: dataTypes.int },
+                                { code: dataTypes.text },
+                            ],
+                        },
+                        3,
+                    ],
+                },
+            ],
+            [
+                "vector<udt<my_udt>, 3>",
+                {
+                    code: dataTypes.custom,
+                    customTypeName: "vector",
+                    info: [{ code: dataTypes.udt, info: "my_udt" }, 3],
+                },
+            ],
+            [
+                "vector<vector<float, 2>, 3>",
+                {
+                    code: dataTypes.custom,
+                    customTypeName: "vector",
+                    info: [
+                        {
+                            code: dataTypes.custom,
+                            customTypeName: "vector",
+                            info: [{ code: dataTypes.float }, 2],
+                        },
+                        3,
+                    ],
+                },
+            ],
+        ];
+
+        parameterized.forEach(([name, expected]) => {
+            it(`should parse ${name}`, function () {
+                assert.deepEqual(dataTypes.getByName(name), expected);
+            });
+        });
+
+        const invalid = [
+            "notatype",
+            "list<notatype>",
+            "vector<notatype, 3>",
+            "tuple<>",
+            "vector<float>",
+            "vector<float, x>",
+            "vector<float, 3, x>",
+            "map<int>",
+            "map<int, text, boolean>",
+        ];
+
+        invalid.forEach((name) => {
+            it(`should reject ${name}`, function () {
+                assert.throws(() => dataTypes.getByName(name), TypeError);
+            });
+        });
+    });
+
     describe("#parseKeyTypes", function () {
         const encoder = new Encoder(1, {});
         it("should parse single type", function () {


### PR DESCRIPTION
Text type hints are resolved by `dataTypes.getByName()`, which split the arguments of a parameterized type without regard for nesting. A parameterized type used as an argument was therefore torn apart, and hints like these were rejected as invalid:
- `map<int, vector<float, 3>>`
- `tuple<vector<float, 3>, int>`
- `map<int, map<int, text>>`
- `tuple<map<int, text>, int>`
- `map<int, tuple<int, text>>`

The arguments are now split by a shared helper that tracks angle bracket depth and only breaks on the commas separating the arguments themselves. Vector finds its dimension the same way, and validates its own argument count rather than relying on the regular expression to do it.

`dataTypes.getByName()` had no direct test coverage at all. Every type hint exercised elsewhere was either a scalar or a parameterized type whose arguments were scalars, so the failing shape was never parsed in a test. The second commit covers every scalar type name, the partial hints, case and whitespace handling, each container holding a parameterized argument, and the names that must be rejected.

Fixes: #380

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass tests.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~[ ] I have provided docstrings for the public items that I want to introduce.~
- ~[ ] I have made sure that the type stubs / TS definitions match the JS public API.~
- ~[ ] I have adjusted the documentation in `./docs/source/`.~
- ~[ ] I have adjusted the migration documentation (removed/changed API) in `./docs/source/migration-guide`.~
- [x] I added appropriate `Fixes:` annotations to PR description.
