### PR TITLE
Run unit and integration tests on ARM64

### DIFF
--- a/.github/common/integration/action.yml
+++ b/.github/common/integration/action.yml
@@ -4,7 +4,9 @@ description: "Runs integration tests on a single architecture and node version"
 inputs:
   build-command:
     required: true
-    type: string
+  scylla-arch:
+    description: "Architecture of the ScyllaDB package installed by CCM"
+    required: true
 
 runs:
   using: "composite"
@@ -29,11 +31,13 @@ runs:
       env:
         CCM_IS_SCYLLA: "true"
         CCM_PATH: "./scylla-ccm"
+        SCYLLA_ARCH: ${{ inputs.scylla-arch }}
       shell: bash
       run: npm run integration
     - name: Run integration tests on scylla with expose-gc
       env:
         CCM_IS_SCYLLA: "true"
         CCM_PATH: "./scylla-ccm"
+        SCYLLA_ARCH: ${{ inputs.scylla-arch }}
       shell: bash
       run: npm run integration-gc

--- a/.github/workflows/extended-ci.yml
+++ b/.github/workflows/extended-ci.yml
@@ -46,21 +46,35 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        settings:
+        host:
+          - ubuntu-latest
+          - ubuntu-24.04-arm
+        node: [ 20, 22, 24, current ]
+        include:
           - host: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-            build: npm run build -- --target x86_64-unknown-linux-gnu
-        node: [ 20, 22, 24, current ]
-    name: Build and run integration tests - ${{ matrix.settings.target }} - node@${{ matrix.node }}
-    runs-on: ${{ matrix.settings.host }}
+            scylla_arch: x86_64
+          - host: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+            scylla_arch: aarch64
+        exclude:
+          - host: ubuntu-24.04-arm
+            node: 22
+          - host: ubuntu-24.04-arm
+            node: 24
+          - host: ubuntu-24.04-arm
+            node: current
+    name: Build and run integration tests - ${{ matrix.target }} - node@${{ matrix.node }}
+    runs-on: ${{ matrix.host }}
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/common/setup
         with:
-          host: ${{ matrix.settings.host }}
-          target: ${{ matrix.settings.target }}
+          host: ${{ matrix.host }}
+          target: ${{ matrix.target }}
           node-version: ${{ matrix.node }}
       - uses: ./.github/common/integration
         with:
-          build-command: ${{ matrix.settings.build }}
+          build-command: npm run build:test -- --target ${{ matrix.target }}
+          scylla-arch: ${{ matrix.scylla_arch }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -26,7 +26,10 @@ jobs:
         settings:
           - host: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-            build: npm run build:test -- --target x86_64-unknown-linux-gnu
+            scylla_arch: x86_64
+          - host: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+            scylla_arch: aarch64
     name: Build and run integration tests - ${{ matrix.settings.target }} - node@20
     runs-on: ${{ matrix.settings.host }}
     timeout-minutes: 60
@@ -39,4 +42,5 @@ jobs:
           node-version: 20
       - uses: ./.github/common/integration
         with:
-          build-command: ${{ matrix.settings.build }}
+          build-command: npm run build:test -- --target ${{ matrix.settings.target }}
+          scylla-arch: ${{ matrix.settings.scylla_arch }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,8 +84,8 @@ jobs:
           CCM_IS_SCYLLA: "true"
           CCM_PATH: "./scylla-ccm"
         run: npm run integration
-  # We test examples only on aarch64, as we cannot run integration test on this platform 
-  # (For more information see MAINTENANCE.md, section Integration tests).
+  # Integration tests on aarch64 run in integration-tests.yml and extended-ci.yml.
+  # This release-specific job verifies the built package by running the examples.
   test-aarch64-unknown-linux-gnu-examples:
     needs:
       - build

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -19,16 +19,22 @@ jobs:
   build-and-run-tests:
     strategy:
       fail-fast: false
-    name: Build and run unit tests - node@20
-    runs-on: ubuntu-latest
+      matrix:
+        settings:
+          - host: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - host: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+    name: Build and run unit tests - ${{ matrix.settings.target }} - node@20
+    runs-on: ${{ matrix.settings.host }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/common/setup
         with:
-          host: ubuntu-latest
-          target: x86_64-unknown-linux-gnu
+          host: ${{ matrix.settings.host }}
+          target: ${{ matrix.settings.target }}
       - name: Build
-        run: npm run build -- --target x86_64-unknown-linux-gnu
+        run: npm run build -- --target ${{ matrix.settings.target }}
         shell: bash
       - name: Run unit tests
         run: npm run unit

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -75,14 +75,15 @@ launched through CCM. Split between regular and extended CI is not yet decided.
 
 #### Integration tests
 
-|               | Linux x64  | Linux arm**| MacOS Intel  | MacOS Arm  |
+ARM and x64 run the same integration test suites. ARM uses Node 20 to verify architecture-specific
+behavior, while the extended x64 matrix verifies compatibility with every supported Node version.
+
+|               | Linux x64  | Linux arm  | MacOS Intel  | MacOS Arm  |
 |-------------- |----------- |----------- |------------- |----------- |
-| Node 20       | ✅         | ❌         | ❌ (planned) | ❌         |
+| Node 20       | ✅         | ✅         | ❌ (planned) | ❌         |
 | Node 22       | 🟠         | ❌         | ❌ (planned) | ❌         |
 | Node 24       | 🟠         | ❌         | ❌ (planned) | ❌         |
 | Node current  | 🟠         | ❌         | ❌ (planned) | ❌         |
-
-**) Disabled due to problems with ccm
 
 ## Releasing process
 


### PR DESCRIPTION
## Why

ARM64 release artifacts need native unit and integration coverage. Repeating the full Node.js matrix on both architectures would add cost without changing the executed suites.

## What

- Add native Ubuntu ARM64 unit and integration jobs on Node.js 20.
- Configure CCM to download the matching ARM64 ScyllaDB package.
- Keep the full Node.js version matrix on x86_64.
- Update maintenance and release documentation.

Fixes #524