### PR TITLE
Deduplicate branch and pull request CI triggers

### DIFF
--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -4,7 +4,8 @@ name: Check docs
 on:
   push:
     branches:
-      - "**"
+      - main
+      - "branch-**"
   pull_request:
     branches:
       - '**'

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -4,7 +4,8 @@ env:
 "on":
   push:
     branches:
-      - "**"
+      - main
+      - "branch-**"
   pull_request:
     branches:
       - '**'

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -6,7 +6,8 @@ env:
 "on":
   push:
     branches:
-      - "**"
+      - main
+      - "branch-**"
   pull_request:
     branches:
       - '**'

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -10,7 +10,8 @@ env:
 "on":
   push:
     branches:
-      - "**"
+      - main
+      - "branch-**"
   pull_request:
     branches:
       - '**'

--- a/.github/workflows/typescript-tests.yml
+++ b/.github/workflows/typescript-tests.yml
@@ -4,7 +4,8 @@ env:
 "on":
   push:
     branches:
-      - "**"
+      - main
+      - "branch-**"
   pull_request:
     branches:
       - '**'

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -7,7 +7,8 @@ env:
 "on":
   push:
     branches:
-      - "**"
+      - main
+      - "branch-**"
   pull_request:
     branches:
       - '**'


### PR DESCRIPTION
## Why

Feature-branch commits trigger both push and pull_request workflows, running the same CI work twice.

## What

- Run feature-branch CI through pull_request events.
- Retain push CI for main and branch-**.
- Apply the trigger policy to docs, code quality, examples, integration, TypeScript, and unit workflows.