### PR TITLE
Implement Host.isUp

### DIFF
--- a/docs/source/migration-guide/migration-guide.md
+++ b/docs/source/migration-guide/migration-guide.md
@@ -200,6 +200,11 @@ when using `client.hosts.keys()` - see issue [#282](https://github.com/scylladb/
 (they were checked in the driver tests). Those assumptions no longer hold true,
 the hosts returned from `client.hosts.keys()` may be in a random order, that may vary from run to run.
 
+### UP/DOWN distinction
+
+Previously, the Host was set as UP or DOWN as a result of received events. Now, whether a Host is considered
+as UP depends on whether it has an established open connection with the driver.
+
 #### `Host.address` is now a `net.SocketAddress`
 
 In the `cassandra-driver`, `host.address` was a plain string in the `ip:port` format.
@@ -230,6 +235,7 @@ raw `Buffer`.
   open-source Cassandra and ScyllaDB clusters, which have no DSE version to report.
 - `workloads` (getter/setter): also DSE-specific (e.g. the Search/Analytics/Graph workloads DSE
   assigns to nodes); not applicable outside DSE.
+- `canBeConsideredAsUp()`: determines if the host can be considered as UP – use `Host.isUp()` instead.
 
 `HostMap`:
 

--- a/lib/host.ts
+++ b/lib/host.ts
@@ -65,6 +65,11 @@ class Host extends events.EventEmitter {
     hostId: Uuid;
 
     /**
+     * Live handle to this node in the Rust driver's cluster state.
+     */
+    #node: rust.NodeHandle;
+
+    /**
      * Creates a new Host instance.
      *
      * Instances of this class are constructed directly from the native code when reading cluster metadata.
@@ -76,8 +81,10 @@ class Host extends events.EventEmitter {
         datacenter: string | null,
         rack: string | null,
         hostId: Buffer,
+        node: rust.NodeHandle,
     ) {
         super();
+        this.#node = node;
         this.address = address;
         this.cassandraVersion = null;
         this.datacenter = datacenter;
@@ -85,14 +92,14 @@ class Host extends events.EventEmitter {
         this.tokens = [];
         this.hostId = Uuid.fromRust(hostId);
     }
-
     /**
-     * This endpoint is not yet implemented, and its usage will throw an error
+     * Determines if the node is UP now and the driver has working connections to it.
      *
-     * Determines if the node is UP now (seen as UP by the driver).
+     * In particular, if there's a network partition and the node is seen as UP by other nodes
+     * but driver has no connections to it, then this will return `false`.
      */
     isUp(): boolean {
-        throw new Error(`TODO: Not implemented`);
+        return this.#node.isConnected();
     }
 
     /**

--- a/lib/host.ts
+++ b/lib/host.ts
@@ -105,16 +105,6 @@ class Host extends events.EventEmitter {
     /**
      * This endpoint is not yet implemented, and its usage will throw an error
      *
-     * Determines if the host can be considered as UP.
-     * Deprecated: Use {@link Host#isUp()} instead.
-     */
-    canBeConsideredAsUp(): boolean {
-        throw new Error(`TODO: Not implemented`);
-    }
-
-    /**
-     * This endpoint is not yet implemented, and its usage will throw an error
-     *
      * Returns an array containing the Cassandra Version as an Array of Numbers having the major version in the first
      * position.
      */

--- a/src/metadata/host.rs
+++ b/src/metadata/host.rs
@@ -43,6 +43,25 @@ pub(crate) fn cache_host_map(
     NapiRef::new(env, host_map)
 }
 
+/// A live handle to a node of the Rust driver's cluster state.
+///
+/// Everything else a `Host` exposes is a snapshot: the address, datacenter, rack and host id are
+/// copied out of the `Node` when the `Host` is built. Liveness cannot be snapshotted the same
+/// way. Holding the `Arc<Node>` lets the value be read afresh on every call.
+#[napi]
+pub struct NodeHandle {
+    inner: Arc<Node>,
+}
+
+#[napi]
+impl NodeHandle {
+    /// Whether the driver currently holds at least one working connection to this node.
+    #[napi]
+    pub fn is_connected(&self) -> bool {
+        self.inner.is_connected()
+    }
+}
+
 /// Builds the arguments passed to the JS Host constructor for the given node.
 fn host_ctor_args<'a>(node: &'a Arc<Node>, env: &'a Env) -> napi::Result<HostCtorArgs<'a>> {
     let address = SocketAddr::new(node.address.ip(), node.address.port());
@@ -53,6 +72,9 @@ fn host_ctor_args<'a>(node: &'a Arc<Node>, env: &'a Env) -> napi::Result<HostCto
         node.datacenter.as_deref(),
         node.rack.as_deref(),
         CopyableBuffer::new(node.host_id.as_bytes().as_slice()),
+        NodeHandle {
+            inner: Arc::clone(node),
+        },
     )))
 }
 

--- a/src/utils/js_ctor.rs
+++ b/src/utils/js_ctor.rs
@@ -5,6 +5,7 @@ use napi::bindgen_prelude::{
 use std::collections::HashMap;
 use std::sync::Mutex;
 
+use crate::metadata::host::NodeHandle;
 use crate::types::type_helpers::SocketAddrWrapper;
 use crate::types::type_wrappers::ComplexType;
 use crate::utils::js_instance::JsInstance;
@@ -47,6 +48,7 @@ pub(crate) type HostCtorArgs<'a> = FnArgs<(
     Option<&'a str>,
     Option<&'a str>,
     CopyableBuffer<'a>,
+    NodeHandle,
 )>;
 
 /// Arguments passed to `HostMap(items)`.

--- a/test/integration/supported/metadata-host-tests.js
+++ b/test/integration/supported/metadata-host-tests.js
@@ -128,4 +128,56 @@ describe("Client#hosts", function () {
             done();
         });
     });
+
+    describe("when cluster changes", function () {
+        const setupInfo = helper.setup("3:0");
+        const client = setupInfo.client;
+        let hostToTest;
+
+        before(function () {
+            hostToTest = helper.findHost(client, 3, true);
+        });
+
+        // Stop node 3 before the next test.
+        before((done) => helper.ccmHelper.stopNode(3, done));
+
+        // Wait for the driver to detect that node 3 is down.
+        before(async () => await helper.wait.forNodeDown(client, 3));
+
+        it("should report a host as down when the node is stopped", function (done) {
+            assert.isFalse(
+                hostToTest.isUp(),
+                `Host ${hostToTest.addressToString()} should be down after stopping`,
+            );
+
+            // Verify other hosts are still up.
+            const hosts = client.hosts.values();
+            hosts.slice(1).forEach((host) => {
+                if (host.address.address !== hostToTest.address.address) {
+                    assert.isTrue(
+                        host.isUp(),
+                        `Host ${host.addressToString()} should still be up`,
+                    );
+                }
+            });
+
+            done();
+        });
+
+        context("when the node is restarted", function () {
+            // Restart node 3 before the next test.
+            before((done) => helper.ccmHelper.startNode(3, done));
+
+            // Wait for the driver to detect that node 3 is back up.
+            before(async () => await helper.wait.forNodeUp(client, 3));
+
+            it("should report a host as up again", function (done) {
+                assert.isTrue(
+                    hostToTest.isUp(),
+                    `Host ${hostToTest.addressToString()} should be up after restart`,
+                );
+                done();
+            });
+        });
+    });
 });


### PR DESCRIPTION
Everything a `Host` exposed was a snapshot: the address, datacenter, rack and host id were copied out of the `Node` when the `Host` is built. Liveness cannot be snapshotted the same way. It requires holding the `Arc<Node>` for the value to be read afresh on every call.

Adds a `nodeHandle` napi struct, holding the `Arc<Node>` inside, and implements `Host.isUp` by adding a private `#node` field to the `Host`.

Remove the already deprecated `canBeConsideredAsUp` method.

### Tests

- Unit tests (test/unit/host-tests.js):
  - Updated test helpers to accept and pass node parameters
  - Added tests verifying `isUp()` correctly reflects node connectivity state
- Integration tests (test/integration/supported/metadata-host-tests.js):
  - Added test suite that stops/restarts a node in a 3-node cluster
  - Verifies `isUp()` returns false when a node is stopped
  - Verifies `isUp()` returns true when the node comes back online
  - Uses `helper.wait.forNodeDown()` and `helper.wait.forNodeUp()` for reliable state detection

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass tests.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- [x] I have made sure that the type stubs / TS definitions match the JS public API.
- ~[ ] I have adjusted the documentation in `./docs/source/`.~
- ~[ ] I have adjusted the migration documentation (removed/changed API) in `./docs/source/migration-guide`.~
- ~[ ] I added appropriate `Fixes:` annotations to PR description.~
