### PR TITLE
Add ddl helper for schema changes in tests

### DIFF
--- a/src/tests/ddl_test_helpers.rs
+++ b/src/tests/ddl_test_helpers.rs
@@ -1,0 +1,106 @@
+use std::sync::Arc;
+
+use scylla::client::execution_profile::ExecutionProfileBuilder;
+use scylla::errors::{DbError, RequestAttemptError};
+use scylla::policies::load_balancing::{NodeIdentifier, SingleTargetLoadBalancingPolicy};
+use scylla::policies::retry::{RequestInfo, RetryDecision, RetryPolicy, RetrySession};
+use scylla::statement::Statement;
+use uuid::Uuid;
+
+use crate::errors::{JsResult, with_custom_error_async};
+use crate::result::QueryResultWrapper;
+use crate::session::SessionWrapper;
+use crate::types::encoded_data::EncodedValuesWrapper;
+
+/// Message ScyllaDB returns when a schema change collides with another one being applied at
+/// (roughly) the same time.
+const GROUP0_CONFLICT_MESSAGE: &str =
+    "Failed to apply group 0 change due to concurrent modification";
+
+/// How many times a DDL statement is retried after a group 0 conflict.
+const MAX_DDL_RETRIES: usize = 10;
+
+/// Retries a DDL statement, on the same target it was already sent to, when it fails
+/// specifically because of a group 0 conflict. Any other error is not retried here.
+#[derive(Debug, Default)]
+struct DdlRetrySession {
+    attempts: usize,
+}
+
+impl RetrySession for DdlRetrySession {
+    fn decide_should_retry(&mut self, request_info: RequestInfo) -> RetryDecision {
+        let is_group0_conflict = matches!(
+            request_info.error,
+            RequestAttemptError::DbError(DbError::ServerError, message)
+                if message == GROUP0_CONFLICT_MESSAGE
+        );
+        if !is_group0_conflict {
+            return RetryDecision::DontRetry;
+        }
+
+        self.attempts += 1;
+        if self.attempts >= MAX_DDL_RETRIES {
+            tracing::error!(
+                "Received the {}th group 0 concurrent modification error during a DDL \
+                 statement; giving up.",
+                self.attempts
+            );
+            RetryDecision::DontRetry
+        } else {
+            tracing::warn!(
+                "Received a group 0 concurrent modification error during a DDL statement; \
+                 retrying (attempt #{}).",
+                self.attempts
+            );
+            RetryDecision::RetrySameTarget(None)
+        }
+    }
+
+    fn reset(&mut self) {
+        *self = Self::default();
+    }
+}
+
+#[derive(Debug)]
+struct DdlRetryPolicy;
+
+impl RetryPolicy for DdlRetryPolicy {
+    fn new_session(&self) -> Box<dyn RetrySession> {
+        Box::new(DdlRetrySession::default())
+    }
+}
+
+fn apply_ddl_lbp(statement: &mut Statement, host_id: Uuid) {
+    let profile = ExecutionProfileBuilder::default()
+        .load_balancing_policy(SingleTargetLoadBalancingPolicy::new(
+            NodeIdentifier::HostId(host_id),
+            Some(0),
+        ))
+        .retry_policy(Arc::new(DdlRetryPolicy))
+        .build();
+    statement.set_execution_profile_handle(Some(profile.into_handle()));
+}
+
+/// Helper for executing DDL statements in tests.
+#[napi(ts_return_type = "Promise<QueryResultWrapper>")]
+pub async fn ddl(session: &SessionWrapper, query: String) -> JsResult<QueryResultWrapper> {
+    with_custom_error_async(async || {
+        let inner_session = session.inner.get_session();
+        let target_host_id = inner_session
+            .get_cluster_state()
+            .get_nodes_info()
+            .first()
+            .map(|node| node.host_id);
+
+        let mut statement: Statement = query.into();
+        if let Some(host_id) = target_host_id {
+            apply_ddl_lbp(&mut statement, host_id);
+        }
+
+        let result = inner_session
+            .query_unpaged(statement, Vec::<EncodedValuesWrapper>::new())
+            .await?;
+        QueryResultWrapper::from_query(result)
+    })
+    .await
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,5 +1,6 @@
 pub mod client_routes_proxy_tests;
 pub mod client_routes_tests;
+pub mod ddl_test_helpers;
 pub mod js_results_tests;
 pub mod logging_tests;
 pub mod napi_ref_tests;

--- a/test/integration/broken/client-metadata-tests-long.js
+++ b/test/integration/broken/client-metadata-tests-long.js
@@ -185,8 +185,9 @@ describe("Client", function () {
                         ));
 
                 it("should return false when executing DDL queries", () =>
-                    client
-                        .execute(
+                    helper
+                        .ddl(
+                            client,
                             "CREATE KEYSPACE ks_rs_is_schema_in_agreement" +
                                 " WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor' : 1}",
                         )
@@ -208,7 +209,7 @@ describe("Client", function () {
 
                     utils.series(
                         [
-                            (next) => client.execute(createQuery, next),
+                            helper.toDdlTask(client, createQuery),
                             (next) =>
                                 client.metadata.checkSchemaAgreement(
                                     (err, agreement) => {

--- a/test/integration/broken/metadata-tests.js
+++ b/test/integration/broken/metadata-tests.js
@@ -75,23 +75,19 @@ describe("metadata @SERVER_API", function () {
                             );
                             next();
                         },
-                        helper.toTask(
-                            client.execute,
+                        helper.toDdlTask(
                             client,
                             "CREATE KEYSPACE ks1 WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 3}",
                         ),
-                        helper.toTask(
-                            client.execute,
+                        helper.toDdlTask(
                             client,
                             "CREATE KEYSPACE ks2 WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 2}",
                         ),
-                        helper.toTask(
-                            client.execute,
+                        helper.toDdlTask(
                             client,
                             "CREATE KEYSPACE ks3 WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 1}",
                         ),
-                        helper.toTask(
-                            client.execute,
+                        helper.toDdlTask(
                             client,
                             "CREATE KEYSPACE ks4 WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1' : 1}",
                         ),
@@ -126,8 +122,7 @@ describe("metadata @SERVER_API", function () {
                             );
                             next();
                         },
-                        helper.toTask(
-                            client.execute,
+                        helper.toDdlTask(
                             client,
                             "ALTER KEYSPACE ks3 WITH replication = {'class' : 'NetworkTopologyStrategy', 'dc1' : 1}",
                         ),
@@ -156,8 +151,7 @@ describe("metadata @SERVER_API", function () {
                     assert.ok(!m.keyspaces["ks_todelete"]);
                     utils.series(
                         [
-                            helper.toTask(
-                                client.execute,
+                            helper.toDdlTask(
                                 client,
                                 helper.createKeyspaceCql("ks_todelete", 1),
                             ),
@@ -165,8 +159,7 @@ describe("metadata @SERVER_API", function () {
                                 assert.ok(m.keyspaces["ks_todelete"]);
                                 next();
                             },
-                            helper.toTask(
-                                client.execute,
+                            helper.toDdlTask(
                                 client,
                                 "DROP KEYSPACE ks_todelete",
                             ),
@@ -204,18 +197,15 @@ describe("metadata @SERVER_API", function () {
                 utils.series(
                     [
                         client.connect.bind(client),
-                        helper.toTask(
-                            client.execute,
+                        helper.toDdlTask(
                             client,
                             "CREATE KEYSPACE ksrf1 WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 1}",
                         ),
-                        helper.toTask(
-                            client.execute,
+                        helper.toDdlTask(
                             client,
                             "CREATE KEYSPACE ksrf2 WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 2}",
                         ),
-                        helper.toTask(
-                            client.execute,
+                        helper.toDdlTask(
                             client,
                             "CREATE KEYSPACE ksntsrf2 WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1' : 2}",
                         ),
@@ -324,14 +314,13 @@ describe("metadata @SERVER_API", function () {
                 utils.series(
                     [
                         helper.toTask(client.connect, client),
-                        helper.toTask(
-                            client.execute,
+                        helper.toDdlTask(
                             client,
                             helper.createKeyspaceCql("ks_udt1", 2),
                         ),
                         helper.toTask(client.execute, client, "USE ks_udt1"),
-                        helper.toTask(client.execute, client, createUdtQuery1),
-                        helper.toTask(client.execute, client, createUdtQuery2),
+                        helper.toDdlTask(client, createUdtQuery1),
+                        helper.toDdlTask(client, createUdtQuery2),
                         function checkPhoneUdt(next) {
                             const m = client.metadata;
                             m.getUdt(
@@ -1672,8 +1661,7 @@ describe("metadata @SERVER_API", function () {
                 utils.series(
                     [
                         client.connect.bind(client),
-                        helper.toTask(
-                            client.execute,
+                        helper.toDdlTask(
                             client,
                             "CREATE TABLE ks_tbl_meta.tbl_changing (id uuid PRIMARY KEY, text_sample text)",
                         ),
@@ -1689,8 +1677,7 @@ describe("metadata @SERVER_API", function () {
                                 },
                             );
                         },
-                        helper.toTask(
-                            client.execute,
+                        helper.toDdlTask(
                             client,
                             "ALTER TABLE ks_tbl_meta.tbl_changing ADD new_col1 timeuuid",
                         ),
@@ -1881,8 +1868,7 @@ describe("metadata @SERVER_API", function () {
                 utils.series(
                     [
                         client.connect.bind(client),
-                        helper.toTask(
-                            client.execute,
+                        helper.toDdlTask(
                             client,
                             "CREATE MATERIALIZED VIEW monthlyhigh AS " +
                                 "SELECT game, year, month, score, user, day FROM scores WHERE game IS NOT NULL AND year IS NOT NULL AND" +
@@ -1922,8 +1908,7 @@ describe("metadata @SERVER_API", function () {
                                 },
                             );
                         },
-                        helper.toTask(
-                            client.execute,
+                        helper.toDdlTask(
                             client,
                             "ALTER MATERIALIZED VIEW monthlyhigh" +
                                 " WITH compaction = { 'class' : 'LeveledCompactionStrategy' }",
@@ -1951,8 +1936,7 @@ describe("metadata @SERVER_API", function () {
                                 },
                             );
                         },
-                        helper.toTask(
-                            client.execute,
+                        helper.toDdlTask(
                             client,
                             "DROP MATERIALIZED VIEW monthlyhigh",
                         ),
@@ -1980,21 +1964,18 @@ describe("metadata @SERVER_API", function () {
                 utils.series(
                     [
                         client.connect.bind(client),
-                        helper.toTask(
-                            client.execute,
+                        helper.toDdlTask(
                             client,
                             "CREATE TABLE users (user TEXT PRIMARY KEY, first_name TEXT)",
                         ),
                         // create a view using 'select *'.
-                        helper.toTask(
-                            client.execute,
+                        helper.toDdlTask(
                             client,
                             "CREATE MATERIALIZED VIEW users_by_first_all AS SELECT * FROM users" +
                                 " WHERE user IS NOT NULL AND first_name IS NOT NULL PRIMARY KEY (first_name, user)",
                         ),
                         // create same view using 'select <columns>'.
-                        helper.toTask(
-                            client.execute,
+                        helper.toDdlTask(
                             client,
                             "CREATE MATERIALIZED VIEW users_by_first AS" +
                                 " SELECT user, first_name FROM users WHERE user IS NOT NULL AND first_name IS NOT NULL" +
@@ -2055,8 +2036,7 @@ describe("metadata @SERVER_API", function () {
                                 },
                             );
                         },
-                        helper.toTask(
-                            client.execute,
+                        helper.toDdlTask(
                             client,
                             "ALTER TABLE users ADD last_name text",
                         ),
@@ -2220,8 +2200,9 @@ describe("metadata @SERVER_API", function () {
                     ));
 
             it("should return true when executing DDL queries", () =>
-                client
-                    .execute(
+                helper
+                    .ddl(
+                        client,
                         "CREATE KEYSPACE ks_rs_is_schema_in_agreement" +
                             " WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 1}",
                     )

--- a/test/integration/broken/udf-tests.js
+++ b/test/integration/broken/udf-tests.js
@@ -28,7 +28,9 @@ vdescribe("2.2", "Metadata @SERVER_API", function () {
         ];
         utils.eachSeries(
             queries,
-            client.execute.bind(client),
+            function (query, next) {
+                helper.ddl(client, query).then(() => next(), next);
+            },
             helper.finish(client, done),
         );
     });
@@ -298,8 +300,7 @@ vdescribe("2.2", "Metadata @SERVER_API", function () {
                 [
                     client.connect.bind(client),
                     nonSyncClient.connect.bind(nonSyncClient),
-                    helper.toTask(
-                        client.execute,
+                    helper.toDdlTask(
                         client,
                         "CREATE FUNCTION stringify(i int) RETURNS NULL ON NULL INPUT RETURNS text LANGUAGE java AS 'return Integer.toString(i);'",
                     ),
@@ -329,8 +330,7 @@ vdescribe("2.2", "Metadata @SERVER_API", function () {
                             next,
                         );
                     },
-                    helper.toTask(
-                        client.execute,
+                    helper.toDdlTask(
                         client,
                         "CREATE OR REPLACE FUNCTION stringify(i int) RETURNS NULL ON NULL INPUT RETURNS text LANGUAGE java AS 'return Integer.toString(i) + \"hello\";'",
                     ),
@@ -620,8 +620,7 @@ vdescribe("2.2", "Metadata @SERVER_API", function () {
                 [
                     client.connect.bind(client),
                     nonSyncClient.connect.bind(nonSyncClient),
-                    helper.toTask(
-                        client.execute,
+                    helper.toDdlTask(
                         client,
                         "CREATE AGGREGATE ks_udf.sum2(int) SFUNC plus STYPE int INITCOND 0",
                     ),
@@ -648,8 +647,7 @@ vdescribe("2.2", "Metadata @SERVER_API", function () {
                             next,
                         );
                     },
-                    helper.toTask(
-                        client.execute,
+                    helper.toDdlTask(
                         client,
                         "CREATE OR REPLACE AGGREGATE ks_udf.sum2(int) SFUNC plus STYPE int INITCOND 200",
                     ),

--- a/test/integration/supported/client-batch-tests.js
+++ b/test/integration/supported/client-batch-tests.js
@@ -21,21 +21,12 @@ describe("Client @SERVER_API", function () {
             utils.series(
                 [
                     helper.ccmHelper.start(1),
-                    helper.toTask(
-                        client.execute,
+                    helper.toDdlTask(
                         client,
                         helper.createKeyspaceCql(keyspace, 1),
                     ),
-                    helper.toTask(
-                        client.execute,
-                        client,
-                        helper.createTableCql(table1),
-                    ),
-                    helper.toTask(
-                        client.execute,
-                        client,
-                        helper.createTableCql(table2),
-                    ),
+                    helper.toDdlTask(client, helper.createTableCql(table1)),
+                    helper.toDdlTask(client, helper.createTableCql(table2)),
                 ],
                 done,
             );
@@ -579,18 +570,15 @@ describe("Client @SERVER_API", function () {
             utils.series(
                 [
                     helper.ccmHelper.start(3),
-                    helper.toTask(
-                        client.execute,
+                    helper.toDdlTask(
                         client,
                         helper.createKeyspaceCql(keyspace, 3, false),
                     ),
-                    helper.toTask(
-                        client.execute,
+                    helper.toDdlTask(
                         client,
                         util.format(createTableCql, table1),
                     ),
-                    helper.toTask(
-                        client.execute,
+                    helper.toDdlTask(
                         client,
                         util.format(createTableCql, table2),
                     ),

--- a/test/integration/supported/client-each-row-tests.js
+++ b/test/integration/supported/client-each-row-tests.js
@@ -337,11 +337,10 @@ describe("Client", function () {
             const expectedValues = {};
             utils.series(
                 [
-                    function createTable(next) {
-                        const query =
-                            "CREATE TABLE tbl_map_floats (id text PRIMARY KEY, data map<text, float>)";
-                        client.execute(query, next);
-                    },
+                    helper.toDdlTask(
+                        client,
+                        "CREATE TABLE tbl_map_floats (id text PRIMARY KEY, data map<text, float>)",
+                    ),
                     function insertData(next) {
                         const query =
                             "INSERT INTO tbl_map_floats (id, data) VALUES (?, ?)";
@@ -933,15 +932,14 @@ describe("Client", function () {
             beforeEach((done) => {
                 table =
                     setupInfo.keyspace + "." + helper.getRandomName("table");
-                const queries = [
-                    util.format(
-                        "CREATE TABLE %s (k int, a int, c int, primary key (k, a))",
-                        table,
-                    ),
-                ];
+                const createTableCql = util.format(
+                    "CREATE TABLE %s (k int, a int, c int, primary key (k, a))",
+                    table,
+                );
 
+                const insertQueries = [];
                 for (let i = 0; i < 10; i++) {
-                    queries.push(
+                    insertQueries.push(
                         util.format(
                             "INSERT INTO %s (k, a, c) values (%d,%d,%d)",
                             table,
@@ -951,7 +949,19 @@ describe("Client", function () {
                         ),
                     );
                 }
-                utils.eachSeries(queries, client.execute.bind(client), done);
+                utils.series(
+                    [
+                        helper.toDdlTask(client, createTableCql),
+                        function insertRows(next) {
+                            utils.eachSeries(
+                                insertQueries,
+                                client.execute.bind(client),
+                                next,
+                            );
+                        },
+                    ],
+                    done,
+                );
             });
             it("should be resilient to schema change made between paging", (done) => {
                 const query = util.format("select * from %s", table);
@@ -981,15 +991,22 @@ describe("Client", function () {
                         assert.ok(result);
                         if (result.nextPage) {
                             // make schema change.
-                            client.execute(
-                                util.format("alter table %s add b int", table),
-                                (sErr, sResult) => {
-                                    assert.ifError(sErr);
-                                    schemaChangeMade = true;
-                                    // retrieve next page after schema change is made.
-                                    result.nextPage();
-                                },
-                            );
+                            helper
+                                .ddl(
+                                    client,
+                                    util.format(
+                                        "alter table %s add b int",
+                                        table,
+                                    ),
+                                )
+                                .then(
+                                    () => {
+                                        schemaChangeMade = true;
+                                        // retrieve next page after schema change is made.
+                                        result.nextPage();
+                                    },
+                                    (sErr) => assert.ifError(sErr),
+                                );
                         } else {
                             done();
                         }

--- a/test/integration/supported/client-execute-prepared-tests.js
+++ b/test/integration/supported/client-execute-prepared-tests.js
@@ -401,8 +401,7 @@ describe("Client @SERVER_API", function () {
             const expectedRows = {};
             utils.series(
                 [
-                    helper.toTask(
-                        client.execute,
+                    helper.toDdlTask(
                         client,
                         util.format(
                             "CREATE TABLE %s (id uuid primary key, val varint)",
@@ -472,8 +471,7 @@ describe("Client @SERVER_API", function () {
             const expectedRows = {};
             utils.series(
                 [
-                    helper.toTask(
-                        client.execute,
+                    helper.toDdlTask(
                         client,
                         util.format(
                             "CREATE TABLE %s (id uuid primary key, val decimal)",
@@ -677,7 +675,7 @@ describe("Client @SERVER_API", function () {
             );
             utils.series(
                 [
-                    helper.toTask(client.execute, client, createTableCql),
+                    helper.toDdlTask(client, createTableCql),
                     function insertData(seriesNext) {
                         const query = util.format(
                             "INSERT INTO %s (id, map_text_text, map_int_date, map_date_float, map_varint_boolean, map_timeuuid_text) " +
@@ -794,7 +792,7 @@ describe("Client @SERVER_API", function () {
             );
             utils.series(
                 [
-                    helper.toTask(client.execute, client, createTableCql),
+                    helper.toDdlTask(client, createTableCql),
                     function insertData(seriesNext) {
                         const query = util.format(
                             "INSERT INTO %s (id, set_text, set_timestamp, set_float, set_bigint, set_timeuuid) " +
@@ -951,7 +949,7 @@ describe("Client @SERVER_API", function () {
             client.on("log", helper.log);
             utils.series(
                 [
-                    helper.toTask(client.execute, client, createTableCql),
+                    helper.toDdlTask(client, createTableCql),
                     function insert(next) {
                         const query =
                             "INSERT INTO tbl_nested (id, map1, list1) VALUES (?, ?, ?)";
@@ -1063,7 +1061,7 @@ describe("Client @SERVER_API", function () {
             );
             utils.series(
                 [
-                    helper.toTask(client.execute, client, createQuery),
+                    helper.toDdlTask(client, createQuery),
                     function (next) {
                         const query = util.format(
                             "SELECT * FROM %s WHERE c = ? AND a = ? AND b = 0",
@@ -1372,23 +1370,19 @@ describe("Client @SERVER_API", function () {
                 const client = setupInfo.client;
                 utils.series(
                     [
-                        helper.toTask(
-                            client.execute,
+                        helper.toDdlTask(
                             client,
                             "CREATE TYPE phone (alias text, number text, country_code int, other boolean)",
                         ),
-                        helper.toTask(
-                            client.execute,
+                        helper.toDdlTask(
                             client,
                             'CREATE TYPE address (street text, "ZIP" int, phones set<frozen<phone>>)',
                         ),
-                        helper.toTask(
-                            client.execute,
+                        helper.toDdlTask(
                             client,
                             "CREATE TABLE tbl_udts (id uuid PRIMARY KEY, phone_col frozen<phone>, address_col frozen<address>)",
                         ),
-                        helper.toTask(
-                            client.execute,
+                        helper.toDdlTask(
                             client,
                             "CREATE TABLE tbl_tuples (id uuid PRIMARY KEY, tuple_col1 tuple<text,int>, tuple_col2 tuple<uuid,bigint,boolean>)",
                         ),
@@ -1892,16 +1886,14 @@ describe("Client @SERVER_API", function () {
                 const table = helper.getRandomName("tbl");
                 utils.series(
                     [
-                        helper.toTask(
-                            client.execute,
+                        helper.toDdlTask(
                             client,
                             util.format(
                                 "CREATE TABLE %s (k int PRIMARY KEY, v int)",
                                 table,
                             ),
                         ),
-                        helper.toTask(
-                            client.execute,
+                        helper.toDdlTask(
                             client,
                             util.format(
                                 "CREATE INDEX simple_index ON %s (v)",
@@ -1965,16 +1957,14 @@ describe("Client @SERVER_API", function () {
                     const table = helper.getRandomName("tbl");
                     utils.series(
                         [
-                            helper.toTask(
-                                client.execute,
+                            helper.toDdlTask(
                                 client,
                                 util.format(
                                     "CREATE TABLE %s (k int PRIMARY KEY, v frozen<list<int>>)",
                                     table,
                                 ),
                             ),
-                            helper.toTask(
-                                client.execute,
+                            helper.toDdlTask(
                                 client,
                                 util.format(
                                     "CREATE INDEX frozen_index ON %s (full(v))",
@@ -2034,16 +2024,14 @@ describe("Client @SERVER_API", function () {
                     const table = helper.getRandomName("tbl");
                     utils.series(
                         [
-                            helper.toTask(
-                                client.execute,
+                            helper.toDdlTask(
                                 client,
                                 util.format(
                                     "CREATE TABLE %s (k int PRIMARY KEY, v map<text,int>)",
                                     table,
                                 ),
                             ),
-                            helper.toTask(
-                                client.execute,
+                            helper.toDdlTask(
                                 client,
                                 util.format(
                                     "CREATE INDEX keys_index on %s (keys(v))",
@@ -2126,16 +2114,14 @@ describe("Client @SERVER_API", function () {
                     const table = helper.getRandomName("tbl");
                     utils.series(
                         [
-                            helper.toTask(
-                                client.execute,
+                            helper.toDdlTask(
                                 client,
                                 util.format(
                                     "CREATE TABLE %s (k int PRIMARY KEY, v map<text,int>)",
                                     table,
                                 ),
                             ),
-                            helper.toTask(
-                                client.execute,
+                            helper.toDdlTask(
                                 client,
                                 util.format(
                                     "CREATE INDEX values_index on %s (v)",
@@ -2209,16 +2195,14 @@ describe("Client @SERVER_API", function () {
                     const table = helper.getRandomName("tbl");
                     utils.series(
                         [
-                            helper.toTask(
-                                client.execute,
+                            helper.toDdlTask(
                                 client,
                                 util.format(
                                     "CREATE TABLE %s (k int PRIMARY KEY, v map<text,int>)",
                                     table,
                                 ),
                             ),
-                            helper.toTask(
-                                client.execute,
+                            helper.toDdlTask(
                                 client,
                                 util.format(
                                     "CREATE INDEX entries_index on %s (entries(v))",
@@ -2535,7 +2519,7 @@ function serializationTest(client, values, columns, done) {
     };
     utils.series(
         [
-            helper.toTask(client.execute, client, helper.createTableCql(table)),
+            helper.toDdlTask(client, helper.createTableCql(table)),
             function (next) {
                 let markers = "?";
                 const columnsSplit = columns.split(",");

--- a/test/integration/supported/client-execute-tests.js
+++ b/test/integration/supported/client-execute-tests.js
@@ -537,13 +537,15 @@ describe("Client @SERVER_API", function () {
 
         vit("2.1", "should encode CONTAINS parameter", function (done) {
             const client = setupInfo.client;
-            client.execute(
-                util.format(
-                    "CREATE INDEX list_sample_index ON %s(list_sample)",
-                    table,
-                ),
-                function (err) {
-                    assert.ifError(err);
+            helper
+                .ddl(
+                    client,
+                    util.format(
+                        "CREATE INDEX list_sample_index ON %s(list_sample)",
+                        table,
+                    ),
+                )
+                .then(() => {
                     // Allow 1 second for index to build (otherwise an IndexNotAvailableException may be raised while index is building).
                     setTimeout(function () {
                         const query = util.format(
@@ -558,8 +560,8 @@ describe("Client @SERVER_API", function () {
                             done();
                         });
                     }, 1000);
-                },
-            );
+                })
+                .catch(done);
         });
         it("should accept localOne and localQuorum consistencies", function (done) {
             const client = setupInfo.client;
@@ -1182,23 +1184,19 @@ describe("Client @SERVER_API", function () {
                 utils.series(
                     [
                         client.connect.bind(client),
-                        helper.toTask(
-                            client.execute,
+                        helper.toDdlTask(
                             client,
                             "CREATE TYPE phone (alias text, number text, country_code int, other boolean)",
                         ),
-                        helper.toTask(
-                            client.execute,
+                        helper.toDdlTask(
                             client,
                             'CREATE TYPE address (street text, "ZIP" int, phones set<frozen<phone>>)',
                         ),
-                        helper.toTask(
-                            client.execute,
+                        helper.toDdlTask(
                             client,
                             "CREATE TABLE tbl_udts (id uuid PRIMARY KEY, phone_col frozen<phone>, address_col frozen<address>)",
                         ),
-                        helper.toTask(
-                            client.execute,
+                        helper.toDdlTask(
                             client,
                             "CREATE TABLE tbl_tuples (id uuid PRIMARY KEY, tuple_col tuple<text,int,blob>)",
                         ),
@@ -1675,8 +1673,7 @@ describe("Client @SERVER_API", function () {
                 const client = setupInfo.client;
                 utils.series(
                     [
-                        helper.toTask(
-                            client.execute,
+                        helper.toDdlTask(
                             client,
                             "CREATE TABLE tbl_smallints (id uuid PRIMARY KEY, smallint_sample smallint, tinyint_sample tinyint, text_sample text)",
                         ),
@@ -1767,7 +1764,7 @@ describe("Client @SERVER_API", function () {
                 const query =
                     "CREATE TABLE tbl_datetimes " +
                     "(id uuid PRIMARY KEY, date_sample date, time_sample time, text_sample text)";
-                setupInfo.client.execute(query, done);
+                helper.ddl(setupInfo.client, query).then(() => done(), done);
             });
             vit(
                 "2.2",
@@ -1864,7 +1861,7 @@ describe("Client @SERVER_API", function () {
                     "  tup frozen<tuple<int, int>>," +
                     "  d date," +
                     "  t time)";
-                client.execute(query, done);
+                helper.ddl(client, query).then(() => done(), done);
             });
             vit(
                 "2.2",

--- a/test/integration/supported/client-pool-tests.js
+++ b/test/integration/supported/client-pool-tests.js
@@ -360,13 +360,9 @@ describe("Client", function () {
                     },
                     function createKeyspace(next) {
                         const tempClient = newInstance();
-                        tempClient.execute(
-                            helper.createKeyspaceCql(keyspace),
-                            function (err) {
-                                assert.ifError(err);
-                                tempClient.shutdown(next);
-                            },
-                        );
+                        helper
+                            .ddl(tempClient, helper.createKeyspaceCql(keyspace))
+                            .then(() => tempClient.shutdown(next), next);
                     },
                     function tryConnectAgain(next) {
                         client.connect(function (err) {

--- a/test/integration/supported/load-balancing-tests-long.js
+++ b/test/integration/supported/load-balancing-tests-long.js
@@ -87,25 +87,23 @@ describe("TokenAwarePolicy", function () {
                 [
                     helper.ccmHelper.start("3:3"),
                     localClient.connect.bind(localClient),
-                    function createKs(next) {
-                        const createQuery =
-                            "CREATE KEYSPACE %s WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1' : %d, 'dc2' : %d}";
-                        localClient.execute(
-                            util.format(createQuery, keyspace, 1, 1),
-                            helper.waitSchema(localClient, next),
-                        );
-                    },
-                    function createTable(next) {
-                        const query = util.format(
+                    helper.toDdlTask(
+                        localClient,
+                        util.format(
+                            "CREATE KEYSPACE %s WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1' : %d, 'dc2' : %d}",
+                            keyspace,
+                            1,
+                            1,
+                        ),
+                    ),
+                    helper.toDdlTask(
+                        localClient,
+                        util.format(
                             "CREATE TABLE %s.%s (id int primary key, name int)",
                             keyspace,
                             table,
-                        );
-                        localClient.execute(
-                            query,
-                            helper.waitSchema(localClient, next),
-                        );
-                    },
+                        ),
+                    ),
                     localClient.shutdown.bind(localClient),
                 ],
                 done,

--- a/test/integration/supported/load-balancing-tests.js
+++ b/test/integration/supported/load-balancing-tests.js
@@ -88,28 +88,43 @@ context("with a reusable 3 node cluster", function () {
     let client = helper.setup("3:0", {}).client;
 
     before(function (done) {
-        utils.eachSeries(
+        utils.series(
             [
                 // In the tests, we have some hardcoded assumptions, which nodes will be contacted (by usage of token aware policy).
                 // Those nodes are determined based on how Vnodes work - meaning that when testing on scylla, we need to disable tablets,
                 // which otherwise break the assumptions about which nodes to expect as part of the request coordinator.
-                helper.keyspaceDefinitionWithTabletsDisabled(
+                helper.toDdlTask(
                     client,
-                    "CREATE KEYSPACE ks_network_rp1 WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1' : 1}",
+                    helper.keyspaceDefinitionWithTabletsDisabled(
+                        client,
+                        "CREATE KEYSPACE ks_network_rp1 WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1' : 1}",
+                    ),
                 ),
-                helper.keyspaceDefinitionWithTabletsDisabled(
+                helper.toDdlTask(
                     client,
-                    "CREATE KEYSPACE ks_network_rp2 WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1' : 2}",
+                    helper.keyspaceDefinitionWithTabletsDisabled(
+                        client,
+                        "CREATE KEYSPACE ks_network_rp2 WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1' : 2}",
+                    ),
                 ),
-                "CREATE TABLE ks_network_rp1.table_b (id int primary key, name int)",
-                "CREATE TABLE ks_network_rp2.table_c (id int primary key, name int)",
-                "CREATE TABLE ks_network_rp2.table_composite (id1 text, id2 text, primary key ((id1, id2)))",
+                helper.toDdlTask(
+                    client,
+                    "CREATE TABLE ks_network_rp1.table_b (id int primary key, name int)",
+                ),
+                helper.toDdlTask(
+                    client,
+                    "CREATE TABLE ks_network_rp2.table_c (id int primary key, name int)",
+                ),
+                helper.toDdlTask(
+                    client,
+                    "CREATE TABLE ks_network_rp2.table_composite (id1 text, id2 text, primary key ((id1, id2)))",
+                ),
                 // Try to prevent consistency issues in the query trace
-                "ALTER KEYSPACE system_traces WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': '1'}",
+                helper.toDdlTask(
+                    client,
+                    "ALTER KEYSPACE system_traces WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': '1'}",
+                ),
             ],
-            function (q, next) {
-                client.execute(q, next);
-            },
             done,
         );
     });

--- a/test/integration/supported/metadata/keyspace-tests.js
+++ b/test/integration/supported/metadata/keyspace-tests.js
@@ -21,13 +21,11 @@ describe("Metadata#getKeyspace()", function () {
         it("should return KeyspaceMetadata for created keyspace", function (done) {
             utils.series(
                 [
-                    helper.toTask(
-                        setupInfo.client.execute,
+                    helper.toDdlTask(
                         setupInfo.client,
                         "CREATE KEYSPACE test_ks WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1}",
                     ),
-                    helper.toTask(
-                        setupInfo.client.execute,
+                    helper.toDdlTask(
                         setupInfo.client,
                         "CREATE TABLE test_ks.test_table (id uuid PRIMARY KEY, name varchar)",
                     ),
@@ -67,11 +65,7 @@ describe("Metadata#getKeyspace()", function () {
             );
             utils.series(
                 [
-                    helper.toTask(
-                        setupInfo.client.execute,
-                        setupInfo.client,
-                        query,
-                    ),
+                    helper.toDdlTask(setupInfo.client, query),
                     function verifyKeyspace(next) {
                         const client = setupInfo.client;
                         const ks = client.metadata.getKeyspace("test_ss");
@@ -94,8 +88,7 @@ describe("Metadata#getKeyspace()", function () {
         it("should reflect keyspace changes after alter", function (done) {
             utils.series(
                 [
-                    helper.toTask(
-                        setupInfo.client.execute,
+                    helper.toDdlTask(
                         setupInfo.client,
                         "CREATE KEYSPACE test_alter WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1}",
                     ),
@@ -109,8 +102,7 @@ describe("Metadata#getKeyspace()", function () {
                         );
                         next();
                     },
-                    helper.toTask(
-                        setupInfo.client.execute,
+                    helper.toDdlTask(
                         setupInfo.client,
                         "ALTER KEYSPACE test_alter WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 2}",
                     ),
@@ -132,8 +124,7 @@ describe("Metadata#getKeyspace()", function () {
         it("should return null after dropping keyspace", function (done) {
             utils.series(
                 [
-                    helper.toTask(
-                        setupInfo.client.execute,
+                    helper.toDdlTask(
                         setupInfo.client,
                         "CREATE KEYSPACE test_drop WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1}",
                     ),
@@ -143,8 +134,7 @@ describe("Metadata#getKeyspace()", function () {
                         assert.isNotNull(ks);
                         next();
                     },
-                    helper.toTask(
-                        setupInfo.client.execute,
+                    helper.toDdlTask(
                         setupInfo.client,
                         "DROP KEYSPACE test_drop",
                     ),
@@ -162,8 +152,7 @@ describe("Metadata#getKeyspace()", function () {
         it("should return empty tables/views/udts maps for a keyspace with none", function (done) {
             utils.series(
                 [
-                    helper.toTask(
-                        setupInfo.client.execute,
+                    helper.toDdlTask(
                         setupInfo.client,
                         "CREATE KEYSPACE test_empty_ks WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1}",
                     ),
@@ -186,15 +175,13 @@ describe("Metadata#getKeyspace()", function () {
         it("should report durableWrites correctly", function (done) {
             utils.series(
                 [
-                    helper.toTask(
-                        setupInfo.client.execute,
+                    helper.toDdlTask(
                         setupInfo.client,
                         "CREATE KEYSPACE test_durable_writes_off WITH replication = " +
                             "{'class': 'NetworkTopologyStrategy', 'dc1': 1} " +
                             "AND durable_writes = false",
                     ),
-                    helper.toTask(
-                        setupInfo.client.execute,
+                    helper.toDdlTask(
                         setupInfo.client,
                         "CREATE KEYSPACE test_durable_writes_on WITH replication = " +
                             "{'class': 'NetworkTopologyStrategy', 'dc1': 1} " +
@@ -219,18 +206,15 @@ describe("Metadata#getKeyspace()", function () {
         it("should expose tables keyed by table name", function (done) {
             utils.series(
                 [
-                    helper.toTask(
-                        setupInfo.client.execute,
+                    helper.toDdlTask(
                         setupInfo.client,
                         "CREATE KEYSPACE test_ks_tbls WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1};",
                     ),
-                    helper.toTask(
-                        setupInfo.client.execute,
+                    helper.toDdlTask(
                         setupInfo.client,
                         "CREATE TABLE test_ks_tbls.tbl_1 (id uuid PRIMARY KEY, name varchar)",
                     ),
-                    helper.toTask(
-                        setupInfo.client.execute,
+                    helper.toDdlTask(
                         setupInfo.client,
                         "CREATE TABLE test_ks_tbls.tbl_2 (id uuid PRIMARY KEY, idx int)",
                     ),
@@ -262,18 +246,15 @@ describe("Metadata#getKeyspace()", function () {
         it("should return the same table instance whether getTable() is called before or after tables", function (done) {
             utils.series(
                 [
-                    helper.toTask(
-                        setupInfo.client.execute,
+                    helper.toDdlTask(
                         setupInfo.client,
                         "CREATE KEYSPACE test_ks_tbls_order WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1};",
                     ),
-                    helper.toTask(
-                        setupInfo.client.execute,
+                    helper.toDdlTask(
                         setupInfo.client,
                         "CREATE TABLE test_ks_tbls_order.tbl_1 (id uuid PRIMARY KEY, name varchar)",
                     ),
-                    helper.toTask(
-                        setupInfo.client.execute,
+                    helper.toDdlTask(
                         setupInfo.client,
                         "CREATE TABLE test_ks_tbls_order.tbl_2 (id uuid PRIMARY KEY, idx int)",
                     ),
@@ -311,18 +292,15 @@ describe("Metadata#getKeyspace()", function () {
         it("should expose udts keyed by type name", function (done) {
             utils.series(
                 [
-                    helper.toTask(
-                        setupInfo.client.execute,
+                    helper.toDdlTask(
                         setupInfo.client,
                         "CREATE KEYSPACE test_ks_udts WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1}",
                     ),
-                    helper.toTask(
-                        setupInfo.client.execute,
+                    helper.toDdlTask(
                         setupInfo.client,
                         "CREATE TYPE test_ks_udts.udt_a (x int)",
                     ),
-                    helper.toTask(
-                        setupInfo.client.execute,
+                    helper.toDdlTask(
                         setupInfo.client,
                         "CREATE TYPE test_ks_udts.udt_b (y text)",
                     ),
@@ -354,18 +332,15 @@ describe("Metadata#getKeyspace()", function () {
         it("should return the same UDT instance whether getUdt() is called before or after udts", function (done) {
             utils.series(
                 [
-                    helper.toTask(
-                        setupInfo.client.execute,
+                    helper.toDdlTask(
                         setupInfo.client,
                         "CREATE KEYSPACE test_ks_udts_order WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1}",
                     ),
-                    helper.toTask(
-                        setupInfo.client.execute,
+                    helper.toDdlTask(
                         setupInfo.client,
                         "CREATE TYPE test_ks_udts_order.udt_a (x int)",
                     ),
-                    helper.toTask(
-                        setupInfo.client.execute,
+                    helper.toDdlTask(
                         setupInfo.client,
                         "CREATE TYPE test_ks_udts_order.udt_b (y text)",
                     ),
@@ -401,26 +376,22 @@ describe("Metadata#getKeyspace()", function () {
         it("should expose views keyed by view name", function (done) {
             utils.series(
                 [
-                    helper.toTask(
-                        setupInfo.client.execute,
+                    helper.toDdlTask(
                         setupInfo.client,
                         "CREATE KEYSPACE test_ks_views WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1}",
                     ),
-                    helper.toTask(
-                        setupInfo.client.execute,
+                    helper.toDdlTask(
                         setupInfo.client,
                         "CREATE TABLE test_ks_views.base_tbl (id uuid PRIMARY KEY, name varchar, nr int)",
                     ),
-                    helper.toTask(
-                        setupInfo.client.execute,
+                    helper.toDdlTask(
                         setupInfo.client,
                         "CREATE MATERIALIZED VIEW test_ks_views.by_name AS " +
                             "SELECT * FROM test_ks_views.base_tbl " +
                             "WHERE name IS NOT NULL AND id IS NOT NULL " +
                             "PRIMARY KEY (name, id)",
                     ),
-                    helper.toTask(
-                        setupInfo.client.execute,
+                    helper.toDdlTask(
                         setupInfo.client,
                         "CREATE MATERIALIZED VIEW test_ks_views.by_nr AS " +
                             "SELECT * FROM test_ks_views.base_tbl " +
@@ -464,26 +435,22 @@ describe("Metadata#getKeyspace()", function () {
         it("should return the same view instance whether getMaterializedView() is called before or after views", function (done) {
             utils.series(
                 [
-                    helper.toTask(
-                        setupInfo.client.execute,
+                    helper.toDdlTask(
                         setupInfo.client,
                         "CREATE KEYSPACE test_ks_views_order WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1}",
                     ),
-                    helper.toTask(
-                        setupInfo.client.execute,
+                    helper.toDdlTask(
                         setupInfo.client,
                         "CREATE TABLE test_ks_views_order.base_tbl (id uuid PRIMARY KEY, name varchar, nr int)",
                     ),
-                    helper.toTask(
-                        setupInfo.client.execute,
+                    helper.toDdlTask(
                         setupInfo.client,
                         "CREATE MATERIALIZED VIEW test_ks_views_order.by_name AS " +
                             "SELECT * FROM test_ks_views_order.base_tbl " +
                             "WHERE name IS NOT NULL AND id IS NOT NULL " +
                             "PRIMARY KEY (name, id)",
                     ),
-                    helper.toTask(
-                        setupInfo.client.execute,
+                    helper.toDdlTask(
                         setupInfo.client,
                         "CREATE MATERIALIZED VIEW test_ks_views_order.by_nr AS " +
                             "SELECT * FROM test_ks_views_order.base_tbl " +
@@ -526,13 +493,11 @@ describe("Metadata#getKeyspace()", function () {
             // wrapper around it - and likewise for the tables/columns reached through it.
             utils.series(
                 [
-                    helper.toTask(
-                        setupInfo.client.execute,
+                    helper.toDdlTask(
                         setupInfo.client,
                         "CREATE KEYSPACE test_ks_identity WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1}",
                     ),
-                    helper.toTask(
-                        setupInfo.client.execute,
+                    helper.toDdlTask(
                         setupInfo.client,
                         "CREATE TABLE test_ks_identity.identity_tbl (id uuid PRIMARY KEY)",
                     ),
@@ -569,8 +534,7 @@ describe("Metadata#getKeyspace()", function () {
             // records, so reading it twice does not construct two objects.
             utils.series(
                 [
-                    helper.toTask(
-                        setupInfo.client.execute,
+                    helper.toDdlTask(
                         setupInfo.client,
                         "CREATE KEYSPACE test_ks_strategy_id WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1}",
                     ),
@@ -598,13 +562,11 @@ describe("Metadata#getKeyspace()", function () {
             let ks1, ks2, table1, table2;
             utils.series(
                 [
-                    helper.toTask(
-                        setupInfo.client.execute,
+                    helper.toDdlTask(
                         setupInfo.client,
                         "CREATE KEYSPACE test_ks_tbls_cache WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1} AND durable_writes = true",
                     ),
-                    helper.toTask(
-                        setupInfo.client.execute,
+                    helper.toDdlTask(
                         setupInfo.client,
                         "CREATE TABLE test_ks_tbls_cache.tbl_1 (id uuid PRIMARY KEY, name varchar)",
                     ),
@@ -622,8 +584,7 @@ describe("Metadata#getKeyspace()", function () {
                         assert.strictEqual(ks1.tables["tbl_1"], table1);
                         next();
                     },
-                    helper.toTask(
-                        setupInfo.client.execute,
+                    helper.toDdlTask(
                         setupInfo.client,
                         "ALTER KEYSPACE test_ks_tbls_cache WITH durable_writes = false",
                     ),
@@ -660,13 +621,11 @@ describe("Metadata#getKeyspaces()", function () {
     it("should return a record that includes every created keyspace", function (done) {
         utils.series(
             [
-                helper.toTask(
-                    setupInfo.client.execute,
+                helper.toDdlTask(
                     setupInfo.client,
                     "CREATE KEYSPACE test_ksall_1 WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1}",
                 ),
-                helper.toTask(
-                    setupInfo.client.execute,
+                helper.toDdlTask(
                     setupInfo.client,
                     "CREATE KEYSPACE test_ksall_2 WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 2}",
                 ),
@@ -707,13 +666,11 @@ describe("Metadata#getKeyspaces()", function () {
         // KeyspaceMetadata objects, whichever of the two is called first.
         utils.series(
             [
-                helper.toTask(
-                    setupInfo.client.execute,
+                helper.toDdlTask(
                     setupInfo.client,
                     "CREATE KEYSPACE test_ksall_identity WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1}",
                 ),
-                helper.toTask(
-                    setupInfo.client.execute,
+                helper.toDdlTask(
                     setupInfo.client,
                     "CREATE TABLE test_ksall_identity.identity_tbl (id uuid PRIMARY KEY)",
                 ),
@@ -766,8 +723,7 @@ describe("Metadata#getKeyspaces()", function () {
                     });
                     next();
                 },
-                helper.toTask(
-                    setupInfo.client.execute,
+                helper.toDdlTask(
                     setupInfo.client,
                     "CREATE KEYSPACE test_ksall_order WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1}",
                 ),
@@ -789,8 +745,7 @@ describe("Metadata#getKeyspaces()", function () {
     it("should reflect keyspace changes after alter", function (done) {
         utils.series(
             [
-                helper.toTask(
-                    setupInfo.client.execute,
+                helper.toDdlTask(
                     setupInfo.client,
                     "CREATE KEYSPACE test_ksall_alter WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1}",
                 ),
@@ -802,8 +757,7 @@ describe("Metadata#getKeyspaces()", function () {
                     assert.strictEqual(ks.strategy.datacenterRepfactors.dc1, 1);
                     next();
                 },
-                helper.toTask(
-                    setupInfo.client.execute,
+                helper.toDdlTask(
                     setupInfo.client,
                     "ALTER KEYSPACE test_ksall_alter WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 2}",
                 ),

--- a/test/integration/supported/metadata/materialized-view-tests.js
+++ b/test/integration/supported/metadata/materialized-view-tests.js
@@ -26,13 +26,11 @@ describe("Metadata#getMaterializedView()", function () {
             const keyspace = setupInfo.keyspace;
             utils.series(
                 [
-                    helper.toTask(
-                        setupInfo.client.execute,
+                    helper.toDdlTask(
                         setupInfo.client,
                         `CREATE TABLE ${keyspace}.mv_base_table (id uuid PRIMARY KEY, name varchar)`,
                     ),
-                    helper.toTask(
-                        setupInfo.client.execute,
+                    helper.toDdlTask(
                         setupInfo.client,
                         `CREATE MATERIALIZED VIEW ${keyspace}.mv_by_name AS ` +
                             `SELECT * FROM ${keyspace}.mv_base_table ` +
@@ -74,13 +72,11 @@ describe("Metadata#getMaterializedView()", function () {
             const keyspace = setupInfo.keyspace;
             utils.series(
                 [
-                    helper.toTask(
-                        setupInfo.client.execute,
+                    helper.toDdlTask(
                         setupInfo.client,
                         `CREATE TABLE ${keyspace}.identity_tbl (id uuid PRIMARY KEY, name varchar, nr int)`,
                     ),
-                    helper.toTask(
-                        setupInfo.client.execute,
+                    helper.toDdlTask(
                         setupInfo.client,
                         `CREATE MATERIALIZED VIEW ${keyspace}.by_name AS ` +
                             `SELECT * FROM ${keyspace}.identity_tbl ` +
@@ -116,13 +112,11 @@ describe("Metadata#getMaterializedView()", function () {
             const keyspace = setupInfo.keyspace;
             utils.series(
                 [
-                    helper.toTask(
-                        setupInfo.client.execute,
+                    helper.toDdlTask(
                         setupInfo.client,
                         `CREATE TABLE ${keyspace}.mv_drop_base (id uuid PRIMARY KEY, name varchar)`,
                     ),
-                    helper.toTask(
-                        setupInfo.client.execute,
+                    helper.toDdlTask(
                         setupInfo.client,
                         `CREATE MATERIALIZED VIEW ${keyspace}.mv_drop_view AS ` +
                             `SELECT * FROM ${keyspace}.mv_drop_base ` +
@@ -138,8 +132,7 @@ describe("Metadata#getMaterializedView()", function () {
                         assert.isNotNull(view);
                         next();
                     },
-                    helper.toTask(
-                        setupInfo.client.execute,
+                    helper.toDdlTask(
                         setupInfo.client,
                         `DROP MATERIALIZED VIEW ${keyspace}.mv_drop_view`,
                     ),

--- a/test/integration/supported/metadata/table-tests.js
+++ b/test/integration/supported/metadata/table-tests.js
@@ -34,8 +34,7 @@ describe("Metadata#getTable()", function () {
             const keyspace = setupInfo.keyspace;
             utils.series(
                 [
-                    helper.toTask(
-                        setupInfo.client.execute,
+                    helper.toDdlTask(
                         setupInfo.client,
                         `CREATE TABLE ${keyspace}.test_table (id uuid PRIMARY KEY, name varchar)`,
                     ),
@@ -78,8 +77,7 @@ describe("Metadata#getTable()", function () {
             const keyspace = setupInfo.keyspace;
             utils.series(
                 [
-                    helper.toTask(
-                        setupInfo.client.execute,
+                    helper.toDdlTask(
                         setupInfo.client,
                         `CREATE TABLE ${keyspace}.identity_tbl (id uuid PRIMARY KEY)`,
                     ),
@@ -110,8 +108,7 @@ describe("Metadata#getTable()", function () {
             const keyspace = setupInfo.keyspace;
             utils.series(
                 [
-                    helper.toTask(
-                        setupInfo.client.execute,
+                    helper.toDdlTask(
                         setupInfo.client,
                         `CREATE TABLE ${keyspace}.test_drop (id uuid PRIMARY KEY)`,
                     ),
@@ -123,8 +120,7 @@ describe("Metadata#getTable()", function () {
                         assert.isNotNull(table);
                         next();
                     },
-                    helper.toTask(
-                        setupInfo.client.execute,
+                    helper.toDdlTask(
                         setupInfo.client,
                         `DROP TABLE ${keyspace}.test_drop`,
                     ),

--- a/test/integration/supported/metadata/udt-tests.js
+++ b/test/integration/supported/metadata/udt-tests.js
@@ -25,8 +25,7 @@ describe("Metadata#getUdt()", function () {
             const keyspace = setupInfo.keyspace;
             utils.series(
                 [
-                    helper.toTask(
-                        setupInfo.client.execute,
+                    helper.toDdlTask(
                         setupInfo.client,
                         `CREATE TYPE ${keyspace}.address_udt (street varchar, zip_code int)`,
                     ),
@@ -66,8 +65,7 @@ describe("Metadata#getUdt()", function () {
             const keyspace = setupInfo.keyspace;
             utils.series(
                 [
-                    helper.toTask(
-                        setupInfo.client.execute,
+                    helper.toDdlTask(
                         setupInfo.client,
                         `CREATE TYPE ${keyspace}.identity_udt (x int)`,
                     ),
@@ -95,8 +93,7 @@ describe("Metadata#getUdt()", function () {
             const keyspace = setupInfo.keyspace;
             utils.series(
                 [
-                    helper.toTask(
-                        setupInfo.client.execute,
+                    helper.toDdlTask(
                         setupInfo.client,
                         `CREATE TYPE ${keyspace}.drop_udt (id int)`,
                     ),
@@ -108,8 +105,7 @@ describe("Metadata#getUdt()", function () {
                         assert.isNotNull(udt);
                         next();
                     },
-                    helper.toTask(
-                        setupInfo.client.execute,
+                    helper.toDdlTask(
                         setupInfo.client,
                         `DROP TYPE ${keyspace}.drop_udt`,
                     ),

--- a/test/integration/supported/numeric-tests.js
+++ b/test/integration/supported/numeric-tests.js
@@ -35,8 +35,8 @@ module.exports = function (keyspace, prepare) {
         });
 
         before(() => client.connect());
-        before(() => client.execute(createTableNumericValuesCql));
-        before(() => client.execute(createTableNumericCollectionsCql));
+        before(() => helper.ddl(client, createTableNumericValuesCql));
+        before(() => helper.ddl(client, createTableNumericCollectionsCql));
 
         it("should support setting numeric values using strings", () => {
             const insertQuery = `INSERT INTO tbl_numeric_values
@@ -177,7 +177,8 @@ module.exports = function (keyspace, prepare) {
 
         before(() => client.connect());
         before(() =>
-            client.execute(
+            helper.ddl(
+                client,
                 `CREATE TABLE tbl_integers (id1 text, id2 bigint, varint1 varint, list1 list<bigint>, set1 set<bigint>,
          set2 set<varint>, PRIMARY KEY ((id1, id2)))`,
             ),

--- a/test/integration/supported/paging-tests.js
+++ b/test/integration/supported/paging-tests.js
@@ -29,7 +29,8 @@ module.exports = function (keyspace, prepare) {
 
         before(() => client.connect());
         before(() =>
-            client.execute(
+            helper.ddl(
+                client,
                 "CREATE TABLE tbl_paging (id1 text, id2 int, value text, PRIMARY KEY (id1, id2))",
             ),
         );

--- a/test/integration/supported/workers/worker-threads-tests.js
+++ b/test/integration/supported/workers/worker-threads-tests.js
@@ -176,7 +176,8 @@ describe("Worker threads with database queries @SERVER_API", function () {
         const stressTable = helper.getRandomName("tbl_stress");
 
         before(function () {
-            return setupInfo.client.execute(
+            return helper.ddl(
+                setupInfo.client,
                 `CREATE TABLE ${stressTable} (worker_id int, seq int, value text, PRIMARY KEY ((worker_id), seq))`,
             );
         });

--- a/test/test-helper.js
+++ b/test/test-helper.js
@@ -616,9 +616,8 @@ const helper = {
             );
             before(client.connect.bind(client));
             keyspace = options.keyspace || helper.getRandomName("ks");
-            before(
-                helper.toTask(
-                    client.execute,
+            before(() =>
+                helper.ddl(
                     client,
                     helper.createKeyspaceCql(
                         keyspace,
@@ -628,14 +627,10 @@ const helper = {
             );
             before(helper.toTask(client.execute, client, "USE " + keyspace));
             if (options.queries) {
-                before(function (done) {
-                    utils.eachSeries(
-                        options.queries,
-                        function (q, next) {
-                            client.execute(q, next);
-                        },
-                        done,
-                    );
+                before(async function () {
+                    for (const query of options.queries) {
+                        await helper.ddl(client, query);
+                    }
                 });
             }
             after(client.shutdown.bind(client));
@@ -774,6 +769,20 @@ const helper = {
             replicationFactor || 1,
             !!durableWrites,
         );
+    },
+    /**
+     * Executes a DDL statement, that is a statement creating, altering or dropping
+     * a keyspace, a table or a type.
+     *
+     * ScyllaDB occasionally rejects concurrent schema changes with a group 0 error,
+     * so DDL statements are pinned to a single node/shard and retried on that same
+     * target when it happens.
+     */
+    ddl: async function (client, query) {
+        if (!client.connected) {
+            await client.connect();
+        }
+        return await rust.ddl(client.rustClient, query);
     },
     assertValueEqual: function (val1, val2) {
         if (val1 === null && val2 === null) {
@@ -965,6 +974,15 @@ const helper = {
         return function (next) {
             params.push(next);
             fn.apply(context, params);
+        };
+    },
+    /**
+     * Like `toTask`, but for a DDL statement: bridges `helper.ddl()` (which is Promise-based)
+     * into a Node-style task function.
+     */
+    toDdlTask: function (client, query) {
+        return function (next) {
+            helper.ddl(client, query).then(() => next(), next);
         };
     },
     waitCallback: function (ms, callback) {


### PR DESCRIPTION
Add and use ddl helper, which retries the schema altering statement when a conflict happens.

Heavily inspired by:
https://github.com/scylladb/python-rs-driver/pull/170
and
https://github.com/scylladb/scylla-rust-driver/blob/ab3d56eab36c0d251a872fb162af55f5b67c0843/scylla/tests/integration/utils.rs#L217-L331

Fixes: #528 

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass tests.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [ ] I have made sure that the type stubs / TS definitions match the JS public API.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [ ] I have adjusted the migration documentation (removed/changed API) in `./docs/source/migration-guide`.
- [x] I added appropriate `Fixes:` annotations to PR description.
