### PR TITLE
Add Tests feature

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,9 @@ jobs:
           name: bindings-${{ matrix.settings.target }}
           path: ${{ matrix.settings.files }}
           if-no-files-found: error
-  test-x86_64-unknown-linux-gnu:
+  # Integration tests on x86_64 run in integration-tests.yml and extended-ci.yml.
+  # This release-specific job verifies the built package by running the examples.
+  test-x86_64-unknown-linux-gnu-examples:
     needs:
       - build
     name: test built package - x86_64-unknown-linux-gnu
@@ -71,19 +73,25 @@ jobs:
         run: npm i
       - name: Build TypeScript
         run: npm run build:ts
-      - name: Install ccm
-        # We need a copy of the repo for the ssl tests.
-        # When installing ccm as a package, we do not save the certificates,
-        # that are present in the ./ssl directory
+      - name: Setup 3-node Scylla cluster
         run: |
-          git clone https://github.com/scylladb/scylla-ccm.git
-          pip install --user --upgrade psutil
-          pip install --user https://github.com/scylladb/scylla-ccm/archive/master.zip
-      - name: Run integration tests
-        env:
-          CCM_IS_SCYLLA: "true"
-          CCM_PATH: "./scylla-ccm"
-        run: npm run integration
+          sudo sh -c "echo 2097152 >> /proc/sys/fs/aio-max-nr"
+          docker compose -f .github/docker-compose.yml up -d --wait
+      - name: Install examples dependencies
+        run: |
+          cd examples
+          npm i
+      - name: Run all examples
+        run: SCYLLA_URI=172.42.0.2:9042 npm run examples
+      - name: Stop the cluster
+        if: ${{ always() }}
+        run: docker compose -f .github/docker-compose.yml stop
+      - name: Print the cluster logs
+        if: ${{ always() }}
+        run: docker compose -f .github/docker-compose.yml logs
+      - name: Remove cluster
+        if: ${{ always() }}
+        run: docker compose -f .github/docker-compose.yml down
   # Integration tests on aarch64 run in integration-tests.yml and extended-ci.yml.
   # This release-specific job verifies the built package by running the examples.
   test-aarch64-unknown-linux-gnu-examples:
@@ -125,7 +133,7 @@ jobs:
         run: docker compose -f .github/docker-compose.yml down
   publish:
     needs:
-      - test-x86_64-unknown-linux-gnu
+      - test-x86_64-unknown-linux-gnu-examples
       - test-aarch64-unknown-linux-gnu-examples
     name: Publish
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,14 +73,14 @@ jobs:
         run: npm run build:ts
       - name: Install ccm
         # We need a copy of the repo for the ssl tests.
-        # When installing ccm as a package, we do not save the certificates, 
+        # When installing ccm as a package, we do not save the certificates,
         # that are present in the ./ssl directory
         run: |
           git clone https://github.com/scylladb/scylla-ccm.git
           pip install --user --upgrade psutil
           pip install --user https://github.com/scylladb/scylla-ccm/archive/master.zip
       - name: Run integration tests
-        env: 
+        env:
           CCM_IS_SCYLLA: "true"
           CCM_PATH: "./scylla-ccm"
         run: npm run integration
@@ -163,29 +163,29 @@ jobs:
       # Not necessary for the release, but useful for debugging in case some binaries are missing
       - name: List packages
         run: ls -R ./npm
-      # Platform specific binaries will be released only in the sub-packages. 
+      # Platform specific binaries will be released only in the sub-packages.
       # We do not want them in the main package, where the napi-rs has placed them.
-      - name: Clean up binaries 
+      - name: Clean up binaries
         run: rm *.node
       - name: Dry-run publish
-        # In the next step we publish multiple packages in a single command: 
+        # In the next step we publish multiple packages in a single command:
         # all platform-specific native addon packages and the main driver
         # package. If any package fails mid-publish, we end up with a partial release.
-        # 
+        #
         # Why do we need separate dry runs, but only a single real publish commands?
-        # 
+        #
         # Napi-rs manages releasing sub-packages through prepublish configured command.
         # However prepublish --dry-run flag only skips side-effects
         # without actually validating against the npm registry. To get real
         # validation, we call npm publish --dry-run explicitly on every sub-package.
-        # 
+        #
         # --ignore-scripts is used prevent the prepublishOnly hook (napi prepublish)
         # from running, since that would publish the sub-packages.
         run: |
           (cd npm/linux-x64-gnu && npm publish --dry-run --access public)
           (cd npm/linux-arm64-gnu && npm publish --dry-run --access public)
           npm publish --dry-run --access public --ignore-scripts
-        env: 
+        env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish
         if: github.event_name == 'release' || inputs.publish

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -39,7 +39,7 @@ jobs:
           host: ${{ matrix.settings.host }}
           target: ${{ matrix.settings.target }}
       - name: Build
-        run: npm run build -- --target ${{ matrix.settings.target }}
+        run: npm run build:test -- --target ${{ matrix.settings.target }}
         shell: bash
       - name: Run unit tests
         run: npm run unit

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ scylla-proxy = { version = "0.0.6", optional = true }
 
 [features]
 # Enables the client-routes fake-NLB test helpers in src/tests/client_routes_proxy_tests.rs.
-client-routes-proxy-tests = ["scylla-proxy"]
+tests = ["scylla-proxy"]
 
 [lints.rust]
 unsafe-op-in-unsafe-fn = "warn"

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "scripts": {
     "build:ts": "tsc -p tsconfig.build.json",
     "build": "sh -c 'napi build --platform --release \"$@\" && npm run build:ts' --",
-    "build:test": "sh -c 'napi build --platform --features client-routes-proxy-tests \"$@\" && npm run build:ts' --",
+    "build:test": "sh -c 'napi build --platform --features tests \"$@\" && npm run build:ts' --",
     "all-tests": "npm run unit && npm run integration && npm run unit-not-supported",
     "unit": "./node_modules/.bin/mocha test/unit -t 5000 --recursive",
     "unit-gc": "./node_modules/.bin/mocha --node-option=expose-gc test/unit -t 5000 --recursive --grep 'expose-gc'",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub mod paging;
 pub mod requests;
 pub mod result;
 pub mod session;
+#[cfg(feature = "tests")]
 pub mod tests;
 pub mod tracing_info;
 pub mod types;

--- a/src/tests/client_routes_proxy_tests.rs
+++ b/src/tests/client_routes_proxy_tests.rs
@@ -3,7 +3,7 @@
 //! These wrap `scylla-proxy`'s `nlb` module - the same fake network load balancer
 //! the upstream rust driver's own client-routes integration tests rely on.
 //!
-//! Only compiled when built with the `client-routes-proxy-tests` feature.
+//! Only compiled when built with the `tests` feature.
 
 use std::net::SocketAddr;
 use std::sync::OnceLock;

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "tests")]
 pub mod client_routes_proxy_tests;
 pub mod client_routes_tests;
 pub mod js_results_tests;

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "client-routes-proxy-tests")]
+#[cfg(feature = "tests")]
 pub mod client_routes_proxy_tests;
 pub mod client_routes_tests;
 pub mod js_results_tests;

--- a/src/utils/js_ctor.rs
+++ b/src/utils/js_ctor.rs
@@ -32,6 +32,7 @@ pub mod js_constructible_class {
 }
 
 /// Arguments passed to the test-only `TestJsClass(name, value)` constructor.
+#[cfg(feature = "tests")]
 type TestJsClassCtorArgs<'a> = FnArgs<(&'a str, i32)>;
 
 /// Arguments passed to `net.SocketAddress({ address, port, family })`.
@@ -237,6 +238,7 @@ macro_rules! define_js_ctor {
     };
 }
 
+#[cfg(feature = "tests")]
 define_js_ctor!(
     /// `TestJsClass(name, value)` - test-only class used by `crate::tests::napi_ref_tests`.
     static_name: TEST_JS_CLASS_CTOR,

--- a/src/utils/to_napi_obj.rs
+++ b/src/utils/to_napi_obj.rs
@@ -65,6 +65,9 @@ use crate::utils::js_instance::JsInstance;
 /// {kind: 1} // Case 1
 /// {kind: 2, someData: false} // Case 2
 /// ```
+/// At the moment there is no use case for this macro, except for the test suite,
+/// but it could be useful in the future.
+#[cfg(feature = "tests")]
 macro_rules! define_rust_to_js_convertible_object {
     (pub struct $struct_name: ident{
         $($field_name:ident, $js_name:ident: $field_type:ty),*,
@@ -212,6 +215,9 @@ where
     }
 }
 
+// At the moment there is no use case for this macro, except for the test suite,
+// but it could be useful in the future.
+#[cfg(feature = "tests")]
 pub(crate) use define_rust_to_js_convertible_object;
 
 /// A borrowed byte slice that, when converted to a napi value, is always copied

--- a/test/integration/supported/client-routes-proxy-tests.js
+++ b/test/integration/supported/client-routes-proxy-tests.js
@@ -16,12 +16,6 @@ const helper = require("../../test-helper.js");
 const Client = require("../../../lib/client.js");
 const rust = require("../../../index");
 
-// The fake NLBs this test routes through live behind the `tests` Cargo
-// feature. Skip the whole suite if the feature is not available rather than failing.
-const builtForTesting =
-    typeof rust.testsStartClientRoutesNlbs === "function" &&
-    typeof rust.testsStopClientRoutesNlbs === "function";
-
 const NODE_COUNT = 3;
 const CONNECTION_ID = "nodejs-driver-client-routes-test";
 const REST_API_PORT = 10000;
@@ -31,7 +25,7 @@ const WHOAMI_QUERY = "SELECT host_id FROM system.local WHERE key='local'";
 // Used to make a route unusable on purpose.
 const UNRESOLVABLE_HOSTNAME = "unreachable.invalid";
 
-(builtForTesting ? describe : describe.skip)("Client routes", function () {
+describe("Client routes", function () {
     // Generous, but bounded: posting routes retries the REST API for up to ~20s while a
     // freshly started node warms up, and each test then connects and queries every node.
     this.timeout(60000);

--- a/test/integration/supported/client-routes-proxy-tests.js
+++ b/test/integration/supported/client-routes-proxy-tests.js
@@ -2,7 +2,7 @@
 
 // Integration test for the `clientRoutes` client option.
 //
-// This is only runnable against a native addon built with the `client-routes-proxy-tests`
+// This is only runnable against a native addon built with the `tests`
 // Cargo feature enabled (which we enable for all tests with the `build:test` script).
 //
 // Everything about route refreshing (reacting to CLIENT_ROUTES_CHANGE, topology changes,
@@ -16,7 +16,7 @@ const helper = require("../../test-helper.js");
 const Client = require("../../../lib/client.js");
 const rust = require("../../../index");
 
-// The fake NLBs this test routes through live behind the `client-routes-proxy-tests` Cargo
+// The fake NLBs this test routes through live behind the `tests` Cargo
 // feature. Skip the whole suite if the feature is not available rather than failing.
 const builtForTesting =
     typeof rust.testsStartClientRoutesNlbs === "function" &&


### PR DESCRIPTION
Hide all rust test helpers by the tests feature (previously the client-routes-proxy-tests feature).

Update `unit-tests.yml` to build for testing. 

On release, we verify everything works by running examples instead of the full test suite, which requires the `tests` feature to be enabled.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass tests.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [ ] I have made sure that the type stubs / TS definitions match the JS public API.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [ ] I have adjusted the migration documentation (removed/changed API) in `./docs/source/migration-guide`.
- [ ] I added appropriate `Fixes:` annotations to PR description.
