### PR TITLE
Make all examples follow same pattern and exit with code 1 on error

### DIFF
--- a/examples/basic/basic-connect.js
+++ b/examples/basic/basic-connect.js
@@ -3,19 +3,20 @@ const cassandra = require("@scylladb/driver");
 const { getClientArgs } = require("../util");
 
 const client = new cassandra.Client(getClientArgs());
-client
-    .connect()
-    .then(function () {
-        console.log(
-            "Connected to cluster with %d host(s): %j",
-            client.hosts.length,
-            client.hosts.keys(),
-        );
-        // Currently the driver does not support that metadata field.
-        // console.log("Keyspaces: %j", Object.keys(client.metadata.keyspaces));
-        console.log("Connected to cluster.");
-        return;
-    })
-    .catch(function (err) {
-        console.error("There was an error when connecting", err);
-    });
+
+async function example() {
+    await client.connect();
+    console.log(
+        "Connected to cluster with %d host(s): %j",
+        client.hosts.length,
+        client.hosts.keys(),
+    );
+    // Currently the driver does not support that metadata field.
+    // console.log("Keyspaces: %j", Object.keys(client.metadata.keyspaces));
+    console.log("Connected to cluster.");
+}
+
+example().catch(function (err) {
+    console.error("There was an error", err);
+    process.exitCode = 1;
+});

--- a/examples/basic/basic-execute-flow.js
+++ b/examples/basic/basic-execute-flow.js
@@ -45,5 +45,6 @@ async function example() {
 }
 
 example().catch(function (err) {
-    console.error("There was an error", err.message, err.stack);
+    console.error("There was an error", err);
+    process.exitCode = 1;
 });

--- a/examples/basic/basic-execute.js
+++ b/examples/basic/basic-execute.js
@@ -14,11 +14,7 @@ async function example() {
     console.log("Obtained row: ", row);
 }
 
-example().catch((err) => {
+example().catch(function (err) {
     console.error("There was an error", err);
-});
-
-// Exit on unhandledRejection
-process.on("unhandledRejection", (reason) => {
-    throw reason;
+    process.exitCode = 1;
 });

--- a/examples/concurrent-executions/execute-concurrent-array.js
+++ b/examples/concurrent-executions/execute-concurrent-array.js
@@ -37,9 +37,7 @@ async function example() {
     );
 }
 
-example();
-
-// Exit on unhandledRejection
-process.on("unhandledRejection", (reason) => {
-    throw reason;
+example().catch(function (err) {
+    console.error("There was an error", err);
+    process.exitCode = 1;
 });

--- a/examples/concurrent-executions/execute-in-loop.js
+++ b/examples/concurrent-executions/execute-in-loop.js
@@ -58,9 +58,7 @@ async function executeOneAtATime(info) {
     }
 }
 
-example();
-
-// Exit on unhandledRejection
-process.on("unhandledRejection", (reason) => {
-    throw reason;
+example().catch(function (err) {
+    console.error("There was an error", err);
+    process.exitCode = 1;
 });

--- a/examples/metadata/metadata-hosts.js
+++ b/examples/metadata/metadata-hosts.js
@@ -9,38 +9,37 @@ function socketAddressToString(address) {
 }
 
 const client = new cassandra.Client(getClientArgs());
-client
-    .connect()
-    .then(function () {
-        console.log(
-            "Connected to cluster with %d host(s)",
-            client.hosts.length,
-        );
 
-        // HostMap#forEach() visits every Host, with its id as the second argument.
-        client.hosts.forEach(function (host, hostId) {
-            console.log(
-                "Host %s: %s on dc %s, rack %s",
-                hostId,
-                socketAddressToString(host.address),
-                host.datacenter,
-                host.rack,
-            );
-        });
+async function example() {
+    await client.connect();
+    console.log("Connected to cluster with %d host(s)", client.hosts.length);
 
-        // A specific Host can also be looked up directly, by address or by id.
-        const first = client.hosts.values()[0];
+    // HostMap#forEach() visits every Host, with its id as the second argument.
+    client.hosts.forEach(function (host, hostId) {
         console.log(
-            "Looked up by address: %s",
-            client.hosts.get(socketAddressToString(first.address)) === first,
+            "Host %s: %s on dc %s, rack %s",
+            hostId,
+            socketAddressToString(host.address),
+            host.datacenter,
+            host.rack,
         );
-        console.log(
-            "Looked up by id: %s",
-            client.hosts.get(first.hostId) === first,
-        );
-
-        console.log("Shutting down");
-    })
-    .catch(function (err) {
-        console.error("There was an error when connecting", err);
     });
+
+    // A specific Host can also be looked up directly, by address or by id.
+    const first = client.hosts.values()[0];
+    console.log(
+        "Looked up by address: %s",
+        client.hosts.get(socketAddressToString(first.address)) === first,
+    );
+    console.log(
+        "Looked up by id: %s",
+        client.hosts.get(first.hostId) === first,
+    );
+
+    console.log("Shutting down");
+}
+
+example().catch(function (err) {
+    console.error("There was an error", err);
+    process.exitCode = 1;
+});

--- a/examples/paging/each-row-auto-paged.js
+++ b/examples/paging/each-row-auto-paged.js
@@ -61,5 +61,6 @@ async function example() {
 }
 
 example().catch(function (err) {
-    console.error("There was an error", err.message, err.stack);
+    console.error("There was an error", err);
+    process.exitCode = 1;
 });

--- a/examples/paging/each-row.js
+++ b/examples/paging/each-row.js
@@ -63,5 +63,6 @@ async function example() {
 }
 
 example().catch(function (err) {
-    console.error("There was an error", err.message, err.stack);
+    console.error("There was an error", err);
+    process.exitCode = 1;
 });

--- a/examples/tuple/tuple-insert-select.js
+++ b/examples/tuple/tuple-insert-select.js
@@ -50,4 +50,5 @@ async function example() {
 
 example().catch(function (err) {
     console.error("There was an error", err);
+    process.exitCode = 1;
 });

--- a/examples/udt/udt-insert-select.js
+++ b/examples/udt/udt-insert-select.js
@@ -52,5 +52,6 @@ async function example() {
 }
 
 example().catch(function (err) {
-    console.error(`There was an error ${err}`);
+    console.error("There was an error", err);
+    process.exitCode = 1;
 });


### PR DESCRIPTION
All examples are now presented in a `async function example()` and `example().catch()` pattern, and on error they stop with `process.exitCode = 1`.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass tests.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] I have provided docstrings for the public items that I want to introduce.
- [ ] I have made sure that the type stubs / TS definitions match the JS public API.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [ ] I have adjusted the migration documentation (removed/changed API) in `./docs/source/migration-guide`.
- [ ] I added appropriate `Fixes:` annotations to PR description.
