### PR TITLE
Wire protocolOptions.port into the session contact points

### DIFF
--- a/docs/source/migration-guide/migration-guide.md
+++ b/docs/source/migration-guide/migration-guide.md
@@ -50,6 +50,8 @@ The following options remain unchanged:
 - `encoding.copyBuffer`
 - `encoding.useUndefinedAsUnset`
 - `maxPrepared`
+- `protocolOptions.port`: applied to every contact point that does not carry its own
+  `ipAddress:port` suffix, and defaulting to 9042
 
 The following option implementation has changed significantly,
 but the meaning of the option remains unchanged:

--- a/lib/client-options.js
+++ b/lib/client-options.js
@@ -40,6 +40,9 @@ const { ExecutionProfile } = require("./execution-profile.js");
  * but it is usually a good idea to provide more than one contact point, because if that single contact point is
  * unavailable, the driver will not be able to initialize correctly.
  *
+ * A contact point may carry its own port, as `ipAddress:port` or `[ipv6Address]:port`. That port takes precedence
+ * over `protocolOptions.port`.
+ *
  * @property {Object} [clientRoutes] Client routes configuration, for connecting through proxied setups
  * such as AWS PrivateLink or GCP Private Service Connect.
  *
@@ -135,9 +138,9 @@ const { ExecutionProfile } = require("./execution-profile.js");
  * connect. Default: true.
  * [TODO: Add support for this field]
  * @property {Object} [protocolOptions]
- * @property {Number} [protocolOptions.port] The port to use to connect to the Cassandra host. If not set through this
- * method, the default port (9042) will be used instead.
- * [TODO: Add support for this field]
+ * @property {Number} [protocolOptions.port] The port to use to connect to the Cassandra host. It applies to every
+ * contact point that does not carry its own `ipAddress:port` suffix. If not set through this method, the default port
+ * (9042) will be used instead.
  * @property {Number} [protocolOptions.maxSchemaAgreementWaitSeconds] The maximum time in seconds to wait for schema
  * agreement between nodes before returning from a DDL query. Default: 10.
  * @property {Boolean} [protocolOptions.autoAwaitSchemaAgreement] Determines whether the driver automatically waits

--- a/lib/client-options.js
+++ b/lib/client-options.js
@@ -637,6 +637,15 @@ function validateProtocolOptions(protocolOptions) {
     if (!protocolOptions) {
         throw new TypeError("protocolOptions not defined in options");
     }
+    const port = protocolOptions.port;
+    if (
+        port !== undefined &&
+        (!Number.isSafeInteger(port) || port < 1 || port > 65535)
+    ) {
+        throw new TypeError(
+            "protocolOptions.port must be an integer between 1 and 65535",
+        );
+    }
     const version = protocolOptions.maxVersion;
     if (
         version &&
@@ -937,6 +946,29 @@ function setMetadataDependent(client) {
 }
 
 /**
+ * Appends the port to a contact point that does not already specify one.
+ * @param {String} contactPoint ipAddress, hostName, ipAddress:port or [ipv6Address]:port
+ * @param {Number} port
+ * @returns {String}
+ * @private
+ */
+function withPort(contactPoint, port) {
+    if (contactPoint.startsWith("[")) {
+        return /]:\d+$/.test(contactPoint)
+            ? contactPoint
+            : `${contactPoint}:${port}`;
+    }
+    if (/^[^:]+:\d+$/.test(contactPoint)) {
+        return contactPoint;
+    }
+    // An unbracketed contact point holding a colon is a bare IPv6 address, which
+    // needs brackets before a port can be appended to it.
+    return contactPoint.includes(":")
+        ? `[${contactPoint}]:${port}`
+        : `${contactPoint}:${port}`;
+}
+
+/**
  * Create rust options using js Client options
  * @param {ClientOptions} options
  * @returns {rust.SessionOptions}
@@ -947,7 +979,13 @@ function setRustOptions(options) {
      * @type {rust.SessionOptions}
      */
     let rustOptions = Object();
-    rustOptions.connectPoints = options.contactPoints;
+    const port = options.protocolOptions && options.protocolOptions.port;
+    rustOptions.connectPoints =
+        options.contactPoints && port
+            ? options.contactPoints.map((contactPoint) =>
+                  withPort(contactPoint, port),
+              )
+            : options.contactPoints;
     rustOptions.applicationName = options.applicationName;
     rustOptions.applicationVersion = options.applicationVersion;
     if (options.id instanceof types.Uuid) {

--- a/test/unit/options-tests.js
+++ b/test/unit/options-tests.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const net = require("node:net");
+const { assert } = require("chai");
 const rust = require("../../index");
 const { setRustOptions, extend } = require("../../lib/client-options");
 const {
@@ -89,5 +90,75 @@ describe("Client options", function () {
     });
     it("should correctly verify empty client options", function () {
         extend({ contactPoints: ["1.1.1.1"] });
+    });
+
+    describe("protocolOptions.port", function () {
+        function connectPointsFor(contactPoints, port) {
+            return setRustOptions({
+                contactPoints,
+                protocolOptions: { port },
+            }).connectPoints;
+        }
+
+        it("should append the port to a contact point without one", function () {
+            assert.deepStrictEqual(
+                connectPointsFor(["127.0.0.1", "db.example.com"], 9142),
+                ["127.0.0.1:9142", "db.example.com:9142"],
+            );
+        });
+
+        it("should leave a contact point that already specifies a port", function () {
+            assert.deepStrictEqual(connectPointsFor(["127.0.0.1:9043"], 9142), [
+                "127.0.0.1:9043",
+            ]);
+        });
+
+        it("should bracket a bare IPv6 address before appending the port", function () {
+            assert.deepStrictEqual(connectPointsFor(["::1"], 9142), [
+                "[::1]:9142",
+            ]);
+        });
+
+        it("should append the port to a bracketed IPv6 address without one", function () {
+            assert.deepStrictEqual(connectPointsFor(["[::1]"], 9142), [
+                "[::1]:9142",
+            ]);
+        });
+
+        it("should leave a bracketed IPv6 contact point that already specifies a port", function () {
+            assert.deepStrictEqual(connectPointsFor(["[::1]:9043"], 9142), [
+                "[::1]:9043",
+            ]);
+        });
+
+        it("should apply the default port when protocolOptions is not set", function () {
+            assert.deepStrictEqual(
+                setRustOptions(extend({ contactPoints: ["127.0.0.1"] }))
+                    .connectPoints,
+                ["127.0.0.1:9042"],
+            );
+        });
+
+        it("should reject a port outside the valid range", function () {
+            assert.throws(
+                () =>
+                    extend({
+                        contactPoints: ["127.0.0.1"],
+                        protocolOptions: { port: 65536 },
+                    }),
+                TypeError,
+            );
+        });
+
+        it("should reject a port that is not an integer", function () {
+            assert.throws(
+                () =>
+                    extend({
+                        contactPoints: ["127.0.0.1"],
+                        protocolOptions: { port: "9042" },
+                    }),
+                TypeError,
+            );
+        });
     });
 });


### PR DESCRIPTION
`protocolOptions.port` is declared in `main.d.ts`, documented in `lib/client-options.js` as *"The port to use to connect to the Cassandra host"*, and defaulted to 9042. The value never reaches the session: `setRustOptions` assigns `contactPoints` to `connectPoints` unchanged, so the driver connects on 9042 whatever the caller sets. It is also the only port option, because `ClientOptions` declares no top-level `port`.

Ref: #260, which enumerates this option.

## The problem

Because the discarded value falls back to a reachable port, the failure is silent. A caller who sets `protocolOptions.port` and receives a working client has no signal that the port was dropped, and reads and writes land on whichever cluster answers on 9042.

Given a node on `127.0.0.1:9042` and nothing listening on `127.0.0.1:9999`:

```js
const client = new Client({
    contactPoints: ["127.0.0.1"],
    localDataCenter: "datacenter1",
    protocolOptions: { port: 9999 }, // closed port
});

const result = await client.execute("SELECT host_id FROM system.local");
console.log(String(result.rows[0].host_id));
```

The query succeeds against the node on 9042. `cassandra-driver` 4.9 fails to connect with the same options, which is the expected result.

## The change

- `withPort` appends the configured port to each contact point that does not carry one.
- A contact point that specifies its own port keeps it. With `contactPoints: ["10.0.0.1:9043"]` and `protocolOptions.port: 9142`, the driver connects on 9043. That matches `cassandra-driver`, and it avoids producing `10.0.0.1:9043:9142`.
- A bare IPv6 address gets brackets before the port, so `::1` becomes `[::1]:9042`.
- `validateProtocolOptions` rejects a port that is not an integer between 1 and 65535.
- The migration guide lists `protocolOptions.port` among the client options that remain unchanged.

| Contact point | `protocolOptions.port: 9142` |
|---|---|
| `127.0.0.1` | `127.0.0.1:9142` |
| `db.example.com` | `db.example.com:9142` |
| `::1` | `[::1]:9142` |
| `[::1]` | `[::1]:9142` |
| `127.0.0.1:9043` | `127.0.0.1:9043` |
| `[::1]:9043` | `[::1]:9043` |

`extend` defaults the port to 9042 before `setRustOptions` runs, so a portless contact point always gains a `:9042` suffix. That is a no-op for the resolver, because `resolve_hostname` already falls back to port 9042 for a contact point without one.

The change stays in the JavaScript layer. `main.d.ts` already declares the option, and the rust driver already accepts an `ipAddress:port` known node.

## Tests

`test/unit/options-tests.js` gains a `protocolOptions.port` block covering a contact point with and without a port, a bare and a bracketed IPv6 address in both states, the default port applied through `extend`, and a rejected port.

Verified against ScyllaDB 5.2.9 and 2026.1.12, distinguishing the two nodes by `host_id` from `system.local`. Before the change, `protocolOptions.port: 9999` returns rows from the node on 9042. After it, the connection fails.

`npm run unit`, `npm run unit-not-supported`, `npm run typescript-tests`, ESLint, Prettier, `cargo fmt` and Clippy all pass. `npm run integration` and `npm run examples` were not run, because `ccm` is not installed on the host used. One unrelated case in `test/unit/logging-tests.js` fails on that host: it assumes the connection to `0.0.0.0` fails so that the rust layer emits log events, and the host runs a cluster on `0.0.0.0:9042`.

## Relation to #424

#424 implements this option together with `socketOptions`, `pooling.heartBeatInterval` and `refreshSchemaDelay`. This pull request takes `protocolOptions.port` alone, and handles the contact point that already carries a port, which the review of #424 raised. `protocolOptions.maxSchemaAgreementWaitSeconds` was carved out of #424 the same way.

## Pre-review checklist

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass tests.
- [x] I have provided docstrings for the public items that I want to introduce.
- [x] I have made sure that the type stubs / TS definitions match the JS public API.
- [x] I have adjusted the documentation in `./docs/source/`.
- [x] I have adjusted the migration documentation (removed/changed API) in `./docs/source/migration-guide`.
- [x] I added appropriate `Fixes:` annotations to PR description.
