### PR TITLE
Support for getReplicas

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -19,6 +19,7 @@ Support for some optional driver features is planned for upcoming releases.
    paging/paging
    metadata/schema
    metadata/topology
+   metadata/replicas
    tracing/tracing
    logging/logging
    policies/index
@@ -41,6 +42,7 @@ Contents
 - :doc:`Fetching Large Result Sets <paging/paging>` - Paging through large result sets
 - :doc:`Schema Metadata <metadata/schema>` - Inspecting keyspaces, tables, views and user-defined types
 - :doc:`Cluster Topology <metadata/topology>` - Nodes, addresses, and datacenter awareness
+- :doc:`Replicas <metadata/replicas>` - Host and shard pairs, that replicate a partition
 - :doc:`Query Tracing <tracing/tracing>` - Diagnosing query execution with server-side traces
 - :doc:`Policies <policies/index>` - Load balancing and retry policies
 - :doc:`Authentication <connecting/authentication>` - Connecting with credentials or SSL

--- a/docs/source/metadata/replicas.md
+++ b/docs/source/metadata/replicas.md
@@ -1,0 +1,63 @@
+# Replicas
+
+Replica placement determines which nodes replicate each partition of data in the cluster.
+`client.metadata.getReplicas(keyspaceName, tableName, token)` returns the replicas for a given
+token (partition key), which is useful for token-aware routing and understanding data distribution.
+
+**Note:** This endpoint behaves incorrectly when passed a keyspace that doesn't exist – it walks the
+global ring from token and returns the first node it finds.
+
+## Specifying a partition
+
+The token parameter accepts two forms:
+
+- **Token**: A pre-computed token object, created via `metadata.newToken()`:
+
+  ```javascript
+  const token = client.metadata.newToken(
+    Buffer.from("user-123", "utf8"),
+    "my_keyspace",
+    "my_table"
+  );
+  const replicas = client.metadata.getReplicas("my_keyspace", "my_table", token);
+  ```
+
+- **TokenRange**: A range object; any token within the range identifies its replicas:
+
+  ```javascript
+  const range = client.metadata.getTokenRanges()[0];
+  const replicas = client.metadata.getReplicas("my_keyspace", "my_table", range);
+  ```
+
+## Replica object
+
+Each replica is an object with:
+
+```javascript
+{
+  host: Host,      // The Host object from client.hosts
+  shard: number    // The shard number on that host
+}
+```
+
+The `host` is the exact same `Host` instance that `client.hosts.get()` returns, so you can compare
+by identity:
+
+```javascript
+const replicas = client.metadata.getReplicas("ks", "tbl", token);
+for (const replica of replicas) {
+  const knownHost = client.hosts.get(replica.host.hostId);
+  if (replica.host === knownHost) {
+    console.log(`Partition lives on ${knownHost.address}, shard ${replica.shard}`);
+  }
+}
+```
+
+## Vnode vs. tablet routing
+
+**Vnode-based routing** (traditional): The cluster has one token ring, divided into vnodes (ranges).
+All partitions of a table see the same ranges. `getTokenRanges()` returns the vnode boundaries.
+
+**Tablet-based routing** (ScyllaDB only): Each table is independently divided into tablets
+(fixed-size ranges). `getReplicas()` respects tablet boundaries and returns replicas as reported
+by the server. Tablet placement is learned dynamically as queries are routed.

--- a/docs/source/migration-guide/migration-guide.md
+++ b/docs/source/migration-guide/migration-guide.md
@@ -298,6 +298,25 @@ const token = client.metadata.newToken(Buffer.from("key"), "ks", "tbl");
 const token = new (require("@scylladb/driver").token.Token)(12345n); // wrap a raw value directly
 ```
 
+### Replicas
+
+`getReplicas(keyspaceName, tableName, token)` returns an array of `Replica` objects (node + shard
+pairs) that replicate a partition, given a keyspace, table, and token. See the
+[Replicas](../metadata/replicas.md) page for the full description of the new API.
+
+```javascript
+const replicas = client.metadata.getReplicas("my_keyspace", "my_table", token);
+
+for (const replica of replicas) {
+  console.log(replica.host.address, "shard", replica.shard);
+}
+```
+
+**Key differences from similar methods in `cassandra-driver`:**
+- The token parameter can be a `Token` or a `TokenRange`
+- Each replica includes both the host and its shard number
+- The replica's `host` is the same object instance as `client.hosts.get(hostId)`, so you can compare by identity
+
 ### Schema
 
 The schema metadata API was rewritten from scratch, and almost nothing carries over unchanged.

--- a/lib/host.ts
+++ b/lib/host.ts
@@ -127,6 +127,17 @@ class Host extends events.EventEmitter {
 }
 
 /**
+ * A single replica of a partition: the node that holds it, and the shard of that node it lives
+ * on.
+ */
+interface Replica {
+    /** The node replicating the partition. */
+    host: Host;
+    /** The index of the shard of that node the partition lives on, counting from zero. */
+    shard: number;
+}
+
+/**
  * Represents an associative-array of {@link Host hosts} that can be iterated.
  * It creates an internal copy when adding or removing, making it safe to iterate using the values()
  * method within async operations.
@@ -251,6 +262,7 @@ class HostMap extends events.EventEmitter {
 }
 
 export { Host, HostMap };
+export type { Replica };
 
 // Registers the Host and HostMap constructors, so that Rust can construct fully-formed
 // instances directly when reading cluster metadata.

--- a/lib/metadata/index.ts
+++ b/lib/metadata/index.ts
@@ -10,7 +10,7 @@ import { EmptyCallback, ValueCallback } from "../..";
 // @ts-ignore
 import promiseUtils = require("../promise-utils");
 import { Token, TokenRange, minTokenRange } from "../token";
-import { Host } from "../host";
+import { Host, Replica } from "../host";
 import types = require("../types");
 import { ColumnInfo } from "../types/cql-utils";
 
@@ -76,19 +76,18 @@ class Metadata {
     }
 
     /**
-     * Gets the host list representing the replicas that contain the given partition key, token or token range.
+     * Gets the replicas that contain the given partition key, token or token range.
      *
-     * It uses the pre-loaded keyspace metadata to retrieve the replicas for a token for a given keyspace.
-     * When the keyspace metadata has not been loaded, it returns null.
+     * A replica is the shard of a node the partition lives on, paired with that node.
      * @param {string} keyspaceName Name of the keyspace.
      * @param {Buffer | Token | TokenRange} token Can be Buffer (serialized partition key),
      * Token or TokenRange.
-     * @returns {Host[]} The replicas.
+     * @returns {Replica[]} The replicas.
      */
     getReplicas(
         keyspaceName: string,
         token: Buffer | Token | TokenRange,
-    ): Host[] {
+    ): Replica[] {
         throw new Error("TODO: Not implemented");
     }
 

--- a/lib/metadata/index.ts
+++ b/lib/metadata/index.ts
@@ -79,15 +79,29 @@ class Metadata {
      * Gets the replicas that contain the given token or token range.
      *
      * A replica is the shard of a node the partition lives on, paired with that node.
+     * The hosts returned are the very same objects the {@link Client#hosts} map holds,
+     * so a replica's node can be compared against a host of the cluster by identity.
      * @param {string} keyspaceName Name of the keyspace.
+     * @param {string} tableName Name of the table the token belongs to or empty string if
+     * the table is irrelevant.
      * @param {Token | TokenRange} token Token or TokenRange.
      * @returns {Replica[]} The replicas.
      */
     getReplicas(
         keyspaceName: string,
+        tableName: string,
         token: Token | TokenRange,
     ): Replica[] {
-        throw new Error("TODO: Not implemented");
+        if (token instanceof TokenRange) {
+            // A range is replicated as a whole, so any token it contains identifies its replicas.
+            // The end token is the one it always contains, being its inclusive end.
+            token = token.end;
+        }
+        return this.#rustClient.getReplicas(
+            keyspaceName,
+            tableName,
+            token.getValue(),
+        );
     }
 
     /**

--- a/lib/metadata/index.ts
+++ b/lib/metadata/index.ts
@@ -76,17 +76,16 @@ class Metadata {
     }
 
     /**
-     * Gets the replicas that contain the given partition key, token or token range.
+     * Gets the replicas that contain the given token or token range.
      *
      * A replica is the shard of a node the partition lives on, paired with that node.
      * @param {string} keyspaceName Name of the keyspace.
-     * @param {Buffer | Token | TokenRange} token Can be Buffer (serialized partition key),
-     * Token or TokenRange.
+     * @param {Token | TokenRange} token Token or TokenRange.
      * @returns {Replica[]} The replicas.
      */
     getReplicas(
         keyspaceName: string,
-        token: Buffer | Token | TokenRange,
+        token: Token | TokenRange,
     ): Replica[] {
         throw new Error("TODO: Not implemented");
     }

--- a/main.d.ts
+++ b/main.d.ts
@@ -8,7 +8,7 @@ import * as types from "./lib/types";
 import * as metrics from "./lib/metrics";
 import * as tracker from "./lib/tracker";
 import * as metadata from "./lib/metadata";
-import { Host, HostMap } from "./lib/host";
+import { Host, HostMap, Replica } from "./lib/host";
 import { Token, TokenRange } from "./lib/token";
 import Long = types.Long;
 import Uuid = types.Uuid;
@@ -19,6 +19,7 @@ export * as mapping from "./lib/mapping";
 export * as errors from "./lib/errors";
 export { auth, metadata, metrics, policies, tracker, types };
 export { Host, HostMap };
+export type { Replica };
 
 export const version: number;
 

--- a/src/metadata/host.rs
+++ b/src/metadata/host.rs
@@ -6,10 +6,11 @@ use napi::Env;
 use napi::bindgen_prelude::FnArgs;
 use scylla::cluster::{ClusterState, Node};
 
-use crate::errors::{ConvertedError, JsResult, with_custom_error_sync};
+use crate::errors::{ConvertedError, ConvertedResult, JsResult, with_custom_error_sync};
 use crate::metadata::state::ClusterSnapshot;
 use crate::session::SessionWrapper;
 use crate::types::type_helpers::SocketAddrWrapper;
+use crate::utils::cache::NapiRefCache;
 use crate::utils::js_ctor::{
     HostCtorArgs, build_host, build_host_map, build_socket_address, js_constructible_class,
 };
@@ -17,30 +18,33 @@ use crate::utils::js_instance::JsInstance;
 use crate::utils::napi_ref::NapiRef;
 use crate::utils::to_napi_obj::{CopyableBuffer, NamedMap};
 
-/// Builds a JS `Host` object for every node known via `cluster_state` and collects them into a
-/// single JS `HostMap`, pinning only that map with a `NapiRef`.
+/// Builds a JS `Host` object for every node known via `cluster_state`, pinning each one in
+/// `hosts`, and collects them into a single JS `HostMap`, pinned by the returned `NapiRef`.
 ///
-/// Pinning the `HostMap` alone (rather than each `Host` individually) is enough to keep every
-/// `Host` alive, since the map strongly references all of them. It also means
+/// Keeping the individual hosts in a cache of their own is what lets a single node be looked
+/// up by id later, without going back through the JS map. Pinning the `HostMap` means
 /// `SessionWrapper::get_all_hosts` hands back one already-assembled object instead of rebuilding
 /// a map on the JS side per call, for as long as the cluster state doesn't change.
-pub(crate) fn cache_host_map(
+pub(crate) fn cache_hosts(
     cluster_state: &ClusterState,
     env: &Env,
-) -> napi::Result<NapiRef<js_constructible_class::HostMap>> {
-    let entries = cluster_state
-        .get_nodes_info()
-        .iter()
-        .map(|node| {
-            let host = build_host(env, host_ctor_args(node, env)?)?;
-            let key = node.host_id.simple().to_string();
-            Ok((key, host))
-        })
-        .collect::<napi::Result<HashMap<_, _>>>()?;
+    hosts: &NapiRefCache<js_constructible_class::Host>,
+) -> ConvertedResult<NapiRef<js_constructible_class::HostMap>> {
+    let entries = hosts.get_or_init_all(env, || {
+        cluster_state
+            .get_nodes_info()
+            .iter()
+            .map(|node| {
+                let host = build_host(env, host_ctor_args(node, env)?)?;
+                let key = node.host_id.simple().to_string();
+                Ok((key, host))
+            })
+            .collect::<ConvertedResult<HashMap<_, _>>>()
+    })?;
 
     let items = NamedMap::new(entries);
     let host_map = build_host_map(env, FnArgs::from((items,)))?;
-    NapiRef::new(env, host_map)
+    NapiRef::new(env, host_map).map_err(ConvertedError::from)
 }
 
 /// A live handle to a node of the Rust driver's cluster state.

--- a/src/metadata/host.rs
+++ b/src/metadata/host.rs
@@ -3,13 +3,15 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 
 use napi::Env;
-use napi::bindgen_prelude::FnArgs;
+use napi::bindgen_prelude::{BigInt, FnArgs};
 use scylla::cluster::{ClusterState, Node};
+use scylla::routing::Token;
 
 use crate::errors::{ConvertedError, ConvertedResult, JsResult, with_custom_error_sync};
-use crate::metadata::state::ClusterSnapshot;
+use crate::metadata::state::{ClusterSnapshot, ReplicaValue};
 use crate::session::SessionWrapper;
 use crate::types::type_helpers::SocketAddrWrapper;
+use crate::utils::bigint_to_i64;
 use crate::utils::cache::NapiRefCache;
 use crate::utils::js_ctor::{
     HostCtorArgs, build_host, build_host_map, build_socket_address, js_constructible_class,
@@ -99,6 +101,27 @@ impl SessionWrapper {
                     .host_map
                     .get(env)
                     .map_err(ConvertedError::from)
+            })
+        })
+    }
+
+    /// Returns the replicas of the given token of the given table: each the shard of a node the
+    /// partition lives on, paired with that node. Throws if the keyspace or the table is not found.
+    ///
+    /// The hosts are the very same JS objects `get_all_hosts` hands out, so a replica's node can
+    /// be compared against a host of the cluster by identity.
+    #[napi(ts_return_type = "import('../lib/host').Replica[]")]
+    pub fn get_replicas<'env>(
+        &self,
+        env: &'env Env,
+        keyspace: String,
+        table: String,
+        token: BigInt,
+    ) -> JsResult<Vec<JsInstance<'env, ReplicaValue>>> {
+        with_custom_error_sync(|| {
+            self.with_cluster_snapshot(env, |snapshot| {
+                let token = Token::new(bigint_to_i64(token, "Token value must fit in i64")?);
+                snapshot.replicas(env, &keyspace, &table, token)
             })
         })
     }

--- a/src/metadata/state.rs
+++ b/src/metadata/state.rs
@@ -1,4 +1,6 @@
-use crate::errors::{ConvertedError, ConvertedResult, JsResult, with_custom_error_sync};
+use crate::errors::{
+    ConvertedError, ConvertedResult, JsResult, make_js_error, with_custom_error_sync,
+};
 use crate::metadata::host::cache_hosts;
 use crate::session::SessionWrapper;
 use crate::types::type_wrappers::ComplexType;
@@ -12,10 +14,11 @@ use crate::utils::js_instance::JsInstance;
 use crate::utils::napi_ref::NapiRef;
 use crate::utils::to_napi_obj::NamedMap;
 use napi::Env;
-use napi::bindgen_prelude::{FnArgs, JavaScriptClassExt, Reference};
+use napi::bindgen_prelude::{FnArgs, JavaScriptClassExt, JsObjectValue, Object, Reference};
 use scylla::cluster::metadata::{
     Column, ColumnKind, Keyspace, MaterializedView, Strategy, Table, UserDefinedType,
 };
+use scylla::routing::{Shard, Token};
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -34,6 +37,21 @@ pub enum ViewRecord {}
 /// Tags the `Record<string, Udt>` handed to JS by `KeyspaceMetadata#udts`.
 pub enum UdtRecord {}
 
+/// Tags the `{ host, shard }` object handed to JS by `getReplicas`.
+pub enum ReplicaValue {}
+
+/// Builds the `{ host, shard }` object describing one replica of a partition.
+fn build_replica<'env>(
+    env: &'env Env,
+    host: JsInstance<'env, js_constructible_class::Host>,
+    shard: Shard,
+) -> napi::Result<JsInstance<'env, ReplicaValue>> {
+    let mut replica = Object::new(env)?;
+    replica.set_named_property("host", host)?;
+    replica.set_named_property("shard", shard)?;
+    Ok(JsInstance::from_object(replica))
+}
+
 /// A snapshot of the cluster's topology and schema metadata, as known by the driver
 /// at a given point in time.
 ///
@@ -46,7 +64,6 @@ pub(crate) struct ClusterSnapshot {
     /// All nodes known by the Rust driver at the time this snapshot was created, as JS `Host`
     /// objects keyed by the hex-encoded bytes of their host id. Filled in full when the snapshot
     /// is created.
-    #[expect(unused)]
     hosts: NapiRefCache<js_constructible_class::Host>,
     /// The same nodes, collected into the single JS `HostMap` handed to JS as `client.hosts`.
     ///
@@ -74,6 +91,41 @@ impl ClusterSnapshot {
             keyspace_cache: ReferenceCache::new(),
             keyspaces_record: SingleNapiRefCache::new(),
         })
+    }
+
+    /// The replicas of `token` of the given table: each the shard of a node the partition lives
+    /// on, paired with the very same JS `Host` object this snapshot's `HostMap` holds.
+    ///
+    /// If passed keyspace is unknown, this falls back to Strategy::SimpleStrategy with
+    /// replication_factor = 1, walks the global ring from token and returns the first node it finds.
+    ///
+    /// If keyspace exists and uses tablets, but the table doesn't exist, this uses keyspace's real
+    /// replication strategy over the vnode ring (tablets aren't considered since they can't be
+    /// looked up).
+    pub(crate) fn replicas<'env>(
+        &self,
+        env: &'env Env,
+        keyspace: &str,
+        table: &str,
+        token: Token,
+    ) -> ConvertedResult<Vec<JsInstance<'env, ReplicaValue>>> {
+        self.inner
+            .get_token_endpoints(keyspace, table, token)
+            .into_iter()
+            .map(|(node, shard)| {
+                let host = self
+                    .hosts
+                    .get_or_init(env, &node.host_id.simple().to_string(), || {
+                        ConvertedResult::Ok(None)
+                    })?.ok_or_else(|| {
+                        ConvertedError::from(make_js_error(format!(
+                            "Node {} replicates {token:?} but is not part of the cluster state it was read from",
+                            node.host_id
+                        )))
+                    })?;
+                build_replica(env, host, shard).map_err(ConvertedError::from)
+            })
+            .collect::<ConvertedResult<Vec<_>>>()
     }
 
     /// Returns the cached `KeyspaceWrapper` reference for `name`, converting and caching it lazily

--- a/src/metadata/state.rs
+++ b/src/metadata/state.rs
@@ -1,5 +1,5 @@
 use crate::errors::{ConvertedError, ConvertedResult, JsResult, with_custom_error_sync};
-use crate::metadata::host::cache_host_map;
+use crate::metadata::host::cache_hosts;
 use crate::session::SessionWrapper;
 use crate::types::type_wrappers::ComplexType;
 use crate::utils::cache::{NapiRefCache, ReferenceCache, SingleNapiRefCache};
@@ -43,13 +43,16 @@ pub enum UdtRecord {}
 /// snapshot backing a given `ClusterSnapshot` is stale, by comparing Arc pointers.
 pub(crate) struct ClusterSnapshot {
     pub(crate) inner: Arc<scylla::cluster::ClusterState>,
-    /// All nodes known by the Rust driver at the time this snapshot was created, as a JS `HostMap`
-    /// of `Host` objects keyed by address.
+    /// All nodes known by the Rust driver at the time this snapshot was created, as JS `Host`
+    /// objects keyed by the hex-encoded bytes of their host id. Filled in full when the snapshot
+    /// is created.
+    #[expect(unused)]
+    hosts: NapiRefCache<js_constructible_class::Host>,
+    /// The same nodes, collected into the single JS `HostMap` handed to JS as `client.hosts`.
     ///
-    /// The `NapiRef` releases the JS object it pins automatically when dropped (i.e. when this
+    /// The `NapiRef`s release the JS objects they pin automatically when dropped (i.e. when this
     /// `ClusterSnapshot` itself is dropped, or replaced by a fresher one), so no custom finalizer
-    /// is needed here to avoid leaking a `HostMap` on every cluster state refresh. Pinning the map
-    /// keeps every `Host` it holds alive, so the hosts need no separate `NapiRef`s.
+    /// is needed here to avoid leaking a `HostMap` and its hosts on every cluster state refresh.
     pub(crate) host_map: NapiRef<js_constructible_class::HostMap>,
     /// Cache of keyspaces of this snapshot, populated lazily.
     keyspace_cache: ReferenceCache<KeyspaceWrapper>,
@@ -58,10 +61,15 @@ pub(crate) struct ClusterSnapshot {
 }
 
 impl ClusterSnapshot {
-    pub(crate) fn new(inner: Arc<scylla::cluster::ClusterState>, env: &Env) -> napi::Result<Self> {
-        let host_map = cache_host_map(&inner, env)?;
+    pub(crate) fn new(
+        inner: Arc<scylla::cluster::ClusterState>,
+        env: &Env,
+    ) -> ConvertedResult<Self> {
+        let hosts = NapiRefCache::new();
+        let host_map = cache_hosts(&inner, env, &hosts)?;
         Ok(ClusterSnapshot {
             inner,
+            hosts,
             host_map,
             keyspace_cache: ReferenceCache::new(),
             keyspaces_record: SingleNapiRefCache::new(),

--- a/test/integration/supported/metadata/replica-tests.js
+++ b/test/integration/supported/metadata/replica-tests.js
@@ -1,0 +1,307 @@
+"use strict";
+const assert = require("chai").assert;
+
+const helper = require("../../../test-helper");
+const rust = require("../../../../index");
+
+describe("Metadata replicas", function () {
+    this.timeout(300000);
+
+    const nodeCount = 3;
+    const setupInfo = helper.setup(`${nodeCount}:0`);
+    const replicationFactors = [1, 2, 3];
+    const table = "replicated";
+    const partitionKey = "partition";
+    const otherPartitionKey = "another-partition";
+
+    // One keyspace per replication factor, all of them divided into vnodes, where a placement
+    // follows from the cluster's topology and the replication strategy alone - so every lookup
+    // below is answered without a single request having to be routed first.
+    const vnodeKeyspaces = new Map();
+    // A keyspace divided into tablets, left null where the server has no tablets to divide it by.
+    let tabletKeyspace = null;
+
+    before(async function () {
+        const client = setupInfo.client;
+
+        for (const replicationFactor of replicationFactors) {
+            const keyspace = helper.getRandomName("ks");
+            await helper.ddl(
+                client,
+                helper.keyspaceDefinitionWithTabletsDisabled(
+                    client,
+                    helper.createKeyspaceCql(keyspace, replicationFactor),
+                ),
+            );
+            await createTable(keyspace, table);
+            vnodeKeyspaces.set(replicationFactor, keyspace);
+        }
+
+        if (
+            helper.getServerInfo().isScylla &&
+            (await rust.scyllaSupportsTablets(client.rustClient))
+        ) {
+            tabletKeyspace = helper.getRandomName("ks");
+            await helper.ddl(
+                client,
+                `${helper.createKeyspaceCql(tabletKeyspace, 2)} AND tablets = {'initial': 8}`,
+            );
+            await createTable(tabletKeyspace, table);
+            await learnPlacementOf(partitionKey);
+            await learnPlacementOf(otherPartitionKey);
+        }
+    });
+
+    /**
+     * Creates a table and waits until the driver has read it back.
+     *
+     * A DDL statement is answered as soon as the server has applied it, while the driver learns
+     * of the new schema on its own, so the table is not part of the metadata the instant the
+     * statement returns.
+     */
+    async function createTable(keyspace, name) {
+        await helper.ddl(
+            setupInfo.client,
+            `CREATE TABLE ${keyspace}.${name} (k text PRIMARY KEY)`,
+        );
+    }
+
+    /**
+     * Writes the given partition of the tablets keyspace until the driver knows where it lives.
+     *
+     * The server owns the division into tablets and reports the tablet a request belongs to only
+     * when it had to route the request itself, so a request that happens to land on the right
+     * shard of the right node teaches the driver nothing, and repeating it is what eventually
+     * gets the tablet reported.
+     */
+    async function learnPlacementOf(key) {
+        await helper.wait.until(async () => {
+            await setupInfo.client.execute(
+                `INSERT INTO ${tabletKeyspace}.${table} (k) VALUES (?)`,
+                [key],
+                { prepare: true },
+            );
+            return replicasOf(tabletKeyspace, key).length > 0;
+        });
+    }
+
+    /** The replicas of the given partition key of the given keyspace. */
+    function replicasOf(keyspace, key) {
+        let token = setupInfo.client.metadata.newToken(
+            Buffer.from(key, "utf8"),
+            keyspace,
+            table,
+        );
+        return setupInfo.client.metadata.getReplicas(keyspace, table, token);
+    }
+
+    /**
+     * The given replicas rendered as sorted `host id/shard` strings, so that two replica sets can
+     * be compared whole - a replica being a shard of a node, not the node alone.
+     */
+    function sortedPlacements(replicas) {
+        return replicas
+            .map((replica) => `${replica.host.hostId}/${replica.shard}`)
+            .sort();
+    }
+
+    describe("#getReplicas()", function () {
+        describe("the replicas it returns", function () {
+            it("should be as many as the keyspace's replication factor", function () {
+                for (const [
+                    replicationFactor,
+                    keyspace,
+                ] of vnodeKeyspaces.entries()) {
+                    assert.lengthOf(
+                        replicasOf(keyspace, partitionKey),
+                        replicationFactor,
+                        `keyspace ${keyspace} replicates every partition ${replicationFactor} times`,
+                    );
+                }
+            });
+
+            it("should be the whole cluster when every node replicates everything", function () {
+                const replicas = replicasOf(
+                    vnodeKeyspaces.get(nodeCount),
+                    partitionKey,
+                );
+
+                assert.deepEqual(
+                    replicas
+                        .map((replica) => replica.host.hostId.toString())
+                        .sort(),
+                    setupInfo.client.hosts
+                        .keys()
+                        .map((hostId) => hostId.toString())
+                        .sort(),
+                );
+            });
+
+            it("should each be a node of the cluster, as the very object Client#hosts holds", function () {
+                for (const keyspace of vnodeKeyspaces.values()) {
+                    for (const replica of replicasOf(keyspace, partitionKey)) {
+                        assert.strictEqual(
+                            setupInfo.client.hosts.get(replica.host.hostId),
+                            replica.host,
+                            "a replica's host is not the host object the cluster is made of",
+                        );
+                    }
+                }
+            });
+
+            it("should each name a shard of that node", function () {
+                for (const keyspace of vnodeKeyspaces.values()) {
+                    for (const replica of replicasOf(keyspace, partitionKey)) {
+                        assert.isTrue(
+                            Number.isSafeInteger(replica.shard) &&
+                                replica.shard >= 0,
+                            `shard ${replica.shard} is not the index of a shard`,
+                        );
+                    }
+                }
+            });
+
+            it("should never report the same node twice", function () {
+                for (const [
+                    replicationFactor,
+                    keyspace,
+                ] of vnodeKeyspaces.entries()) {
+                    const replicas = replicasOf(keyspace, partitionKey);
+                    const hostIds = new Set(
+                        replicas.map((replica) =>
+                            replica.host.hostId.toString(),
+                        ),
+                    );
+
+                    assert.lengthOf(
+                        hostIds,
+                        replicationFactor,
+                        "a node was reported as a replica more than once",
+                    );
+                }
+            });
+        });
+
+        describe("the placements it describes", function () {
+            it("should be the same across repeated calls", function () {
+                for (const keyspace of vnodeKeyspaces.values()) {
+                    const first = replicasOf(keyspace, partitionKey);
+                    const second = replicasOf(keyspace, partitionKey);
+
+                    assert.deepEqual(
+                        sortedPlacements(second),
+                        sortedPlacements(first),
+                        "the same partition was placed differently across calls",
+                    );
+                }
+            });
+
+            it("should be the same for a partition key, its token and a range holding it", function () {
+                const metadata = setupInfo.client.metadata;
+                for (const keyspace of vnodeKeyspaces.values()) {
+                    const token = metadata.newToken(
+                        Buffer.from(partitionKey, "utf8"),
+                        keyspace,
+                        table,
+                    );
+                    const range = metadata.newTokenRange(
+                        metadata.newToken(
+                            Buffer.from(otherPartitionKey, "utf8"),
+                            keyspace,
+                            table,
+                        ),
+                        token,
+                    );
+
+                    const fromKey = sortedPlacements(
+                        replicasOf(keyspace, partitionKey),
+                    );
+                    assert.deepEqual(
+                        sortedPlacements(
+                            metadata.getReplicas(keyspace, table, token),
+                        ),
+                        fromKey,
+                    );
+                    assert.deepEqual(
+                        sortedPlacements(
+                            metadata.getReplicas(keyspace, table, range),
+                        ),
+                        fromKey,
+                    );
+                }
+            });
+        });
+
+        describe("when the keyspace is divided into tablets", function () {
+            beforeEach(function () {
+                if (tabletKeyspace === null) {
+                    this.skip();
+                }
+            });
+
+            it("should place a partition on the replicas the server assigned its tablet", async function () {
+                // One row per tablet, holding the token the tablet ends at and the replicas it lives on.
+                const result = await setupInfo.client.execute(
+                    "SELECT keyspace_name, table_name, last_token, replicas" +
+                        " FROM system.tablets",
+                );
+                const rows = result.rows.filter(
+                    (row) =>
+                        row["keyspace_name"] === tabletKeyspace &&
+                        row["table_name"] === table,
+                );
+                assert.isNotEmpty(
+                    rows,
+                    "the server reports no tablets for a keyspace it was asked to divide into them",
+                );
+
+                const token = setupInfo.client.metadata
+                    .newToken(
+                        Buffer.from(partitionKey, "utf8"),
+                        tabletKeyspace,
+                        table,
+                    )
+                    .getValue();
+
+                const tablet = rows
+                    .map((row) => ({
+                        end: BigInt(row["last_token"].toString()),
+                        replicas: row["replicas"],
+                    }))
+                    .sort((a, b) => (a.end < b.end ? -1 : 1))
+                    .find((tablet) => token <= tablet.end);
+
+                // A replica of a tablet is a `(host id, shard)` pair, since a tablet is assigned
+                // to one specific shard of each of its nodes – the same pair the driver reports.
+                const expected = tablet.replicas
+                    .map((replica) => `${replica.get(0)}/${replica.get(1)}`)
+                    .sort();
+                assert.deepEqual(
+                    sortedPlacements(replicasOf(tabletKeyspace, partitionKey)),
+                    expected,
+                );
+            });
+
+            it("should return as many replicas as the keyspace's replication factor", function () {
+                assert.lengthOf(replicasOf(tabletKeyspace, partitionKey), 2);
+            });
+        });
+
+        describe("when passed incorrect parameters", function () {
+            it("should fallback to simple strategy for incorrect keyspace", async function () {
+                const metadata = setupInfo.client.metadata;
+                const token = metadata.newToken(
+                    Buffer.from(partitionKey, "utf8"),
+                    vnodeKeyspaces.get(nodeCount),
+                    table,
+                );
+                let replicas = metadata.getReplicas(
+                    "non-existent-keyspace",
+                    table,
+                    token,
+                );
+                assert.lengthOf(replicas, 1);
+            });
+        });
+    });
+});

--- a/test/typescript/metadata-tests.ts
+++ b/test/typescript/metadata-tests.ts
@@ -1,4 +1,4 @@
-import { Client, Host, metadata, types } from "../../main";
+import { Client, Host, Replica, metadata, types } from "../../main";
 import TableMetadata = metadata.TableMetadata;
 import QueryTrace = metadata.QueryTrace;
 import KeyspaceMetadata = metadata.KeyspaceMetadata;
@@ -16,10 +16,11 @@ async function myTest(): Promise<any> {
     let promise: Promise<void>;
     let n: number;
     let hosts: Host[];
+    let replicas: Replica[];
 
     promise = client.connect();
 
-    hosts = client.metadata.getReplicas("ks1", Buffer.from([0]));
+    replicas = client.metadata.getReplicas("ks1", Buffer.from([0]));
 
     const table: TableMetadata | null = client.metadata.getTable(
         "ks1",

--- a/test/typescript/metadata-tests.ts
+++ b/test/typescript/metadata-tests.ts
@@ -22,7 +22,7 @@ async function myTest(): Promise<any> {
     promise = client.connect();
 
     token = client.metadata.newToken(Buffer.from([0]), "ks1", "table1");
-    replicas = client.metadata.getReplicas("ks1", token);
+    replicas = client.metadata.getReplicas("ks1", "table1", token);
     hosts = replicas.map((replica) => replica.host);
     n = replicas[0].shard;
 

--- a/test/typescript/metadata-tests.ts
+++ b/test/typescript/metadata-tests.ts
@@ -1,4 +1,4 @@
-import { Client, Host, Replica, metadata, types } from "../../main";
+import { Client, Host, Replica, metadata, token, types } from "../../main";
 import TableMetadata = metadata.TableMetadata;
 import QueryTrace = metadata.QueryTrace;
 import KeyspaceMetadata = metadata.KeyspaceMetadata;
@@ -16,11 +16,15 @@ async function myTest(): Promise<any> {
     let promise: Promise<void>;
     let n: number;
     let hosts: Host[];
+    let token: token.Token;
     let replicas: Replica[];
 
     promise = client.connect();
 
-    replicas = client.metadata.getReplicas("ks1", Buffer.from([0]));
+    token = client.metadata.newToken(Buffer.from([0]), "ks1", "table1");
+    replicas = client.metadata.getReplicas("ks1", token);
+    hosts = replicas.map((replica) => replica.host);
+    n = replicas[0].shard;
 
     const table: TableMetadata | null = client.metadata.getTable(
         "ks1",


### PR DESCRIPTION
Implements the `getReplicas(keyspaceName, tableName, token)` endpoint to retrieve which nodes replicate a given partition, along with comprehensive documentation for cluster topology features.

## Changes

**Replicas endpoint**: Returns `Replica[]` (host + shard pairs) for a partition
  - Throws an error if the keyspace or table is not found (instead of returning null)
  - Accepts three input types: `Buffer`, `Token`, or `TokenRange`
  - Respects both vnode-based and tablet-based routing

### Documentation
- **Replicas guide** (`metadata.md`): How to look up replicas, three ways to specify partitions, replica object structure, host identity comparison
- **Topology guide** (NEW `topology.md`): Host properties, HostMap collection, datacenter/rack awareness
- **Migration guide**: Explains that `getReplicas()` key differences

### Testing
- 9 comprehensive integration tests covering:
  - Replica count matches replication factor
  - No duplicate nodes in replicas
  - Host identity consistency with `client.hosts`
  - Consistent placement across repeated calls
  - Vnode and tablet routing modes

Fixes: #531 

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass tests.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- [x] I have made sure that the type stubs / TS definitions match the JS public API.
- [x] I have adjusted the documentation in `./docs/source/`.
- [x] I have adjusted the migration documentation (removed/changed API) in `./docs/source/migration-guide`.
- [x] I added appropriate `Fixes:` annotations to PR description.
