### PR TITLE
Decouple metadata fetches from server-side request timeouts

### DIFF
--- a/docs/source/migration-guide/migration-guide.md
+++ b/docs/source/migration-guide/migration-guide.md
@@ -72,6 +72,13 @@ The following option is new, with no `cassandra-driver` equivalent:
   for schema agreement after a DDL statement before resolving the query, retrying for up to
   `protocolOptions.maxSchemaAgreementWaitSeconds`. See the [Schema Agreement](#schema-agreement)
   section for more information. Defaults to `true`.
+- `protocolOptions.metadataRequestServersideTimeoutSecs`: a ScyllaDB-only server-side timeout applied
+  to schema and topology metadata queries, decoupling them from whatever timeout applies to ordinary
+  requests. Has no effect against a non-ScyllaDB cluster. Defaults to `30`.
+- `protocolOptions.metadataRequestClientsideTimeoutSecs`: a client-side timeout applied to each page
+  fetch of a metadata query, guarding against a node that stops responding without closing the
+  connection. Defaults to `protocolOptions.metadataRequestServersideTimeoutSecs` + 1, or `30` if that
+  is not set either.
 
 ## Client internal members
 

--- a/lib/client-options.js
+++ b/lib/client-options.js
@@ -151,6 +151,11 @@ const { ExecutionProfile } = require("./execution-profile.js");
  * and topology metadata queries, appended to them as a ScyllaDB-only `USING TIMEOUT` clause so that a tight timeout
  * configured elsewhere cannot cause metadata fetches to fail on a large schema. Has no effect against a non-ScyllaDB
  * cluster. Default: 30.
+ * @property {Number} [protocolOptions.metadataRequestClientsideTimeoutSecs] Client-side timeout applied to each page
+ * fetch of a metadata query, guarding against a node that stops responding without closing the connection. When not
+ * set, it is derived as `metadataRequestServersideTimeoutSecs` + 1, or 30 if that is not set either. Setting it below
+ * `metadataRequestServersideTimeoutSecs` is discouraged, as the driver would then abort the request before the
+ * server can report its own, more informative timeout error.
  * @property {Number} [protocolOptions.maxVersion] When set, it limits the maximum protocol version used to connect to
  * the nodes.
  * Useful for using the driver against a cluster that contains nodes with different major/minor versions of Cassandra.
@@ -695,6 +700,18 @@ function validateProtocolOptions(protocolOptions) {
             "protocolOptions.metadataRequestServersideTimeoutSecs must be an integer between 0 and 4294967295",
         );
     }
+    const metadataClientsideTimeout =
+        protocolOptions.metadataRequestClientsideTimeoutSecs;
+    if (
+        metadataClientsideTimeout !== undefined &&
+        (!Number.isSafeInteger(metadataClientsideTimeout) ||
+            metadataClientsideTimeout < 0 ||
+            metadataClientsideTimeout > 0xffffffff)
+    ) {
+        throw new TypeError(
+            "protocolOptions.metadataRequestClientsideTimeoutSecs must be an integer between 0 and 4294967295",
+        );
+    }
 }
 
 /**
@@ -1110,6 +1127,13 @@ function setRustOptions(options) {
         ) {
             rustOptions.metadataRequestServersideTimeoutSecs =
                 options.protocolOptions.metadataRequestServersideTimeoutSecs;
+        }
+        if (
+            options.protocolOptions.metadataRequestClientsideTimeoutSecs !==
+            undefined
+        ) {
+            rustOptions.metadataRequestClientsideTimeoutSecs =
+                options.protocolOptions.metadataRequestClientsideTimeoutSecs;
         }
     }
 

--- a/lib/client-options.js
+++ b/lib/client-options.js
@@ -147,6 +147,10 @@ const { ExecutionProfile } = require("./execution-profile.js");
  * for schema agreement after a DDL statement, retrying for up to `maxSchemaAgreementWaitSeconds`. When `false`, DDL
  * queries return as soon as the coordinator acknowledges them, without waiting for the rest of the cluster to
  * catch up. Default: true.
+ * @property {Number} [protocolOptions.metadataRequestServersideTimeoutSecs] Server-side timeout applied to schema
+ * and topology metadata queries, appended to them as a ScyllaDB-only `USING TIMEOUT` clause so that a tight timeout
+ * configured elsewhere cannot cause metadata fetches to fail on a large schema. Has no effect against a non-ScyllaDB
+ * cluster. Default: 30.
  * @property {Number} [protocolOptions.maxVersion] When set, it limits the maximum protocol version used to connect to
  * the nodes.
  * Useful for using the driver against a cluster that contains nodes with different major/minor versions of Cassandra.
@@ -679,6 +683,18 @@ function validateProtocolOptions(protocolOptions) {
             "protocolOptions.autoAwaitSchemaAgreement must be a boolean value",
         );
     }
+    const metadataServersideTimeout =
+        protocolOptions.metadataRequestServersideTimeoutSecs;
+    if (
+        metadataServersideTimeout !== undefined &&
+        (!Number.isSafeInteger(metadataServersideTimeout) ||
+            metadataServersideTimeout < 0 ||
+            metadataServersideTimeout > 0xffffffff)
+    ) {
+        throw new TypeError(
+            "protocolOptions.metadataRequestServersideTimeoutSecs must be an integer between 0 and 4294967295",
+        );
+    }
 }
 
 /**
@@ -1087,6 +1103,13 @@ function setRustOptions(options) {
         if (options.protocolOptions.autoAwaitSchemaAgreement !== undefined) {
             rustOptions.autoAwaitSchemaAgreement =
                 options.protocolOptions.autoAwaitSchemaAgreement;
+        }
+        if (
+            options.protocolOptions.metadataRequestServersideTimeoutSecs !==
+            undefined
+        ) {
+            rustOptions.metadataRequestServersideTimeoutSecs =
+                options.protocolOptions.metadataRequestServersideTimeoutSecs;
         }
     }
 

--- a/main.d.ts
+++ b/main.d.ts
@@ -254,6 +254,7 @@ export interface ClientOptions {
   protocolOptions?: {
     maxSchemaAgreementWaitSeconds?: number;
     autoAwaitSchemaAgreement?: boolean;
+    metadataRequestServersideTimeoutSecs?: number;
     maxVersion?: number;
     port?: number;
   };

--- a/main.d.ts
+++ b/main.d.ts
@@ -255,6 +255,7 @@ export interface ClientOptions {
     maxSchemaAgreementWaitSeconds?: number;
     autoAwaitSchemaAgreement?: boolean;
     metadataRequestServersideTimeoutSecs?: number;
+    metadataRequestClientsideTimeoutSecs?: number;
     maxVersion?: number;
     port?: number;
   };

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -116,6 +116,7 @@ pub struct SessionOptions {
     cache_size, cacheSize: u32,
     schema_agreement_timeout_secs, schemaAgreementTimeoutSecs: u32,
     auto_await_schema_agreement, autoAwaitSchemaAgreement: bool,
+    metadata_request_serverside_timeout_secs, metadataRequestServersideTimeoutSecs: u32,
     ssl_options, sslOptions: SslOptions,
     load_balancing_config, loadBalancingConfig: LoadBalancingConfig,
     retry_policy, retryPolicy: RetryPolicyKind,
@@ -348,6 +349,10 @@ fn apply_common_options<K: SessionBuilderKindSupportsKnownNodes>(
     }
     if let Some(auto_await_schema_agreement) = options.auto_await_schema_agreement {
         builder = builder.auto_await_schema_agreement(auto_await_schema_agreement);
+    }
+
+    if let Some(secs) = options.metadata_request_serverside_timeout_secs {
+        builder = builder.metadata_request_serverside_timeout(Duration::from_secs(secs as u64));
     }
 
     if let Some(allow_list) = options

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -117,6 +117,7 @@ pub struct SessionOptions {
     schema_agreement_timeout_secs, schemaAgreementTimeoutSecs: u32,
     auto_await_schema_agreement, autoAwaitSchemaAgreement: bool,
     metadata_request_serverside_timeout_secs, metadataRequestServersideTimeoutSecs: u32,
+    metadata_request_clientside_timeout_secs, metadataRequestClientsideTimeoutSecs: u32,
     ssl_options, sslOptions: SslOptions,
     load_balancing_config, loadBalancingConfig: LoadBalancingConfig,
     retry_policy, retryPolicy: RetryPolicyKind,
@@ -353,6 +354,9 @@ fn apply_common_options<K: SessionBuilderKindSupportsKnownNodes>(
 
     if let Some(secs) = options.metadata_request_serverside_timeout_secs {
         builder = builder.metadata_request_serverside_timeout(Duration::from_secs(secs as u64));
+    }
+    if let Some(secs) = options.metadata_request_clientside_timeout_secs {
+        builder = builder.metadata_request_clientside_timeout(Duration::from_secs(secs as u64));
     }
 
     if let Some(allow_list) = options

--- a/src/tests/option_tests.rs
+++ b/src/tests/option_tests.rs
@@ -28,6 +28,7 @@ pub fn tests_check_client_option(options: SessionOptions, test_case: i32) {
                     schema_agreement_timeout_secs: Some(5),
                     auto_await_schema_agreement: Some(false),
                     metadata_request_serverside_timeout_secs: Some(7),
+                    metadata_request_clientside_timeout_secs: Some(9),
                     ssl_options: Some(SslOptions {
                         reject_unauthorized: Some(false),
                         ca: Some(vec!["CA cert 1".to_owned(), "CA cert 2".to_owned()]),
@@ -84,6 +85,7 @@ pub fn tests_check_client_option(options: SessionOptions, test_case: i32) {
                     schema_agreement_timeout_secs: None,
                     auto_await_schema_agreement: None,
                     metadata_request_serverside_timeout_secs: None,
+                    metadata_request_clientside_timeout_secs: None,
                     ssl_options: None,
                     load_balancing_config: None,
                     retry_policy: None,
@@ -107,6 +109,7 @@ pub fn tests_check_client_option(options: SessionOptions, test_case: i32) {
                     schema_agreement_timeout_secs: None,
                     auto_await_schema_agreement: None,
                     metadata_request_serverside_timeout_secs: None,
+                    metadata_request_clientside_timeout_secs: None,
                     ssl_options: None,
                     load_balancing_config: None,
                     retry_policy: None,

--- a/src/tests/option_tests.rs
+++ b/src/tests/option_tests.rs
@@ -27,6 +27,7 @@ pub fn tests_check_client_option(options: SessionOptions, test_case: i32) {
                     cache_size: Some(2137),
                     schema_agreement_timeout_secs: Some(5),
                     auto_await_schema_agreement: Some(false),
+                    metadata_request_serverside_timeout_secs: Some(7),
                     ssl_options: Some(SslOptions {
                         reject_unauthorized: Some(false),
                         ca: Some(vec!["CA cert 1".to_owned(), "CA cert 2".to_owned()]),
@@ -82,6 +83,7 @@ pub fn tests_check_client_option(options: SessionOptions, test_case: i32) {
                     cache_size: None,
                     schema_agreement_timeout_secs: None,
                     auto_await_schema_agreement: None,
+                    metadata_request_serverside_timeout_secs: None,
                     ssl_options: None,
                     load_balancing_config: None,
                     retry_policy: None,
@@ -104,6 +106,7 @@ pub fn tests_check_client_option(options: SessionOptions, test_case: i32) {
                     cache_size: None,
                     schema_agreement_timeout_secs: None,
                     auto_await_schema_agreement: None,
+                    metadata_request_serverside_timeout_secs: None,
                     ssl_options: None,
                     load_balancing_config: None,
                     retry_policy: None,

--- a/test/unit/options-tests.js
+++ b/test/unit/options-tests.js
@@ -62,6 +62,7 @@ const options = {
         maxSchemaAgreementWaitSeconds: 5,
         autoAwaitSchemaAgreement: false,
         metadataRequestServersideTimeoutSecs: 7,
+        metadataRequestClientsideTimeoutSecs: 9,
     },
 };
 

--- a/test/unit/options-tests.js
+++ b/test/unit/options-tests.js
@@ -61,6 +61,7 @@ const options = {
     protocolOptions: {
         maxSchemaAgreementWaitSeconds: 5,
         autoAwaitSchemaAgreement: false,
+        metadataRequestServersideTimeoutSecs: 7,
     },
 };
 


### PR DESCRIPTION
Exposes the two client options:

- `protocolOptions.metadataRequestServersideTimeoutSecs` – a ScyllaDB-only `USING TIMEOUT` applied to schema/topology metadata queries, independent of whatever timeout applies to ordinary requests. Defaults to 30s, no-op against Cassandra.
- `protocolOptions.metadataRequestClientsideTimeoutSecs` – a client-side guard per metadata page fetch, against a node that stops responding without closing the connection. Derived from the server-side value + 1s when unset.

Both map onto `SessionBuilder::metadata_request_serverside_timeout`/`metadata_request_clientside_timeout` respectively.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass tests.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- [x] I have made sure that the type stubs / TS definitions match the JS public API.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [x] I have adjusted the migration documentation (removed/changed API) in `./docs/source/migration-guide`.
- [ ] I added appropriate `Fixes:` annotations to PR description.
